### PR TITLE
Fix base upper bound

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -16,7 +16,7 @@ bug-reports: https://github.com/ryantrinkle/reflex/issues
 library
   hs-source-dirs: src
   build-depends:
-    base >= 4.7 && < 4.9,
+    base >= 4.7 && < 4.10,
     dependent-sum == 0.2.*,
     dependent-map == 0.1.*,
     semigroups >= 0.16 && < 0.18,


### PR DESCRIPTION
Please bump the `base` upper bound.

As far as I can tell, reflex works fine on 4.9 and it's an inconvenience for some projects with many dependencies (like mine) where the only version of `base` they could agree on isn't supported by reflex.