### PR TITLE
Fix template-haskell upper bound

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -24,7 +24,7 @@ library
     containers == 0.5.*,
     these >= 0.4 && < 0.7,
     primitive >= 0.5 && < 0.7,
-    template-haskell >= 2.9 && < 2.11,
+    template-haskell >= 2.9 && < 2.12,
     ref-tf == 0.4.*,
     exception-transformers == 0.4.*,
     transformers >= 0.2,


### PR DESCRIPTION
Please bump the `template-haskell` upper bound.

As far as I can tell, reflex works fine on 2.12 and it's an inconvenience for some projects with many dependencies (like mine) where the only version of TH they could agree on isn't supported by reflex.