### PR TITLE
Added a base monad capable of `PerformEvent`, `PostBuild`, and `TriggerEvent`

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -57,6 +57,7 @@ library
     Data.Functor.Misc,
     Data.WeakBag,
     Reflex,
+    Reflex.Base,
     Reflex.Class,
     Reflex.Dynamic,
     Reflex.Dynamic.TH,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -66,6 +66,8 @@ library
     Reflex.Host.Class,
     Reflex.Optimizer,
     Reflex.Patch,
+    Reflex.TriggerEvent.Base,
+    Reflex.TriggerEvent.Class,
     Reflex.PerformEvent.Base,
     Reflex.PerformEvent.Class,
     Reflex.PostBuild.Class,

--- a/src/Reflex.hs
+++ b/src/Reflex.hs
@@ -2,6 +2,7 @@
 -- you are just getting started with Reflex, this is probably what you want.
 module Reflex (module X) where
 
+import Reflex.Base as X
 import Reflex.Class as X
 import Reflex.Dynamic as X
 import Reflex.Dynamic.TH as X

--- a/src/Reflex.hs
+++ b/src/Reflex.hs
@@ -10,3 +10,4 @@ import Reflex.DynamicWriter as X
 import Reflex.PerformEvent.Class as X
 import Reflex.PostBuild.Class as X
 import Reflex.Spider as X
+import Reflex.TriggerEvent.Class as X

--- a/src/Reflex/Base.hs
+++ b/src/Reflex/Base.hs
@@ -1,0 +1,70 @@
+module Reflex.Base where
+
+import Control.Concurrent
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.Ref
+import Data.Dependent.Sum
+import Data.Foldable
+import Data.Functor.Identity
+import Data.Maybe
+import Data.Traversable
+
+import Reflex.Host.Class
+import Reflex.PerformEvent.Base
+import Reflex.PostBuild.Class
+import Reflex.Spider.Internal
+import Reflex.TriggerEvent.Base
+
+type ReflexBase x = PostBuildT (SpiderTimeline x) (TriggerEventT (SpiderTimeline x) (PerformEventT (SpiderTimeline x) (SpiderHost x)))
+
+-- | Runs a program in a given timeline. Returns the result of the
+-- program, a firing command for firing events in the program, and the
+-- thread id for the event firing thread.
+runReflexBaseForTimeline'
+  :: HasSpiderTimeline x
+  => ReflexBase x a
+  -> SpiderTimelineEnv x
+  -> IO (a, FireCommand (SpiderTimeline x) (SpiderHost x), ThreadId)
+runReflexBaseForTimeline' basic t = do
+  events <- newChan
+  (result, FireCommand fire) <-
+    flip runSpiderHostForTimeline t $ do
+      (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
+      -- Run the various layers of event logic that exist over 'SpiderHost'
+      results@(_, FireCommand fire) <-
+        hostPerformEventT
+          (runTriggerEventT (runPostBuildT basic postBuild) events)
+      -- Read the trigger's ref, traverse into its 'Maybe', and fire the event
+      readRef postBuildTriggerRef >>=
+        traverse_
+          (\postBuildTrigger ->
+             fire [postBuildTrigger :=> Identity ()] $ return ())
+      return results
+  -- Start a thread that fires events forever
+  eventThreadId <-
+    forkIO . forever $ do
+      triggers <- readChan events
+      void . flip runSpiderHostForTimeline t $ do
+        triggersToFire <-
+          liftIO . for triggers $ \(EventTriggerRef tref :=> TriggerInvocation a _) ->
+            fmap (\trigger -> trigger :=> Identity a) <$> readRef tref
+        void . fire (catMaybes triggersToFire) $ return ()
+        liftIO . for_ triggers $ \(_ :=> TriggerInvocation _ cb) -> cb
+      return ()
+  return (result, FireCommand fire, eventThreadId)
+
+-- | Like 'runReflexBasic'', but discards the less relevant outputs.
+runReflexBaseForTimeline
+  :: HasSpiderTimeline x
+  => ReflexBase x a -> SpiderTimelineEnv x -> IO a
+runReflexBaseForTimeline basic =
+  fmap (\(a, _, _) -> a) . runReflexBaseForTimeline' basic
+
+runReflexBase'
+  :: ReflexBase Global a
+  -> IO (a, FireCommand (SpiderTimeline Global) (SpiderHost Global), ThreadId)
+runReflexBase' basic = runReflexBaseForTimeline' basic globalSpiderTimelineEnv
+
+runReflexBase :: ReflexBase Global a -> IO a
+runReflexBase basic = runReflexBaseForTimeline basic globalSpiderTimelineEnv

--- a/src/Reflex/DynamicWriter.hs
+++ b/src/Reflex/DynamicWriter.hs
@@ -32,6 +32,7 @@ import Reflex.Class
 import Reflex.Dynamic
 import Reflex.Host.Class
 import Reflex.PerformEvent.Class
+import Reflex.TriggerEvent.Class
 import Reflex.PostBuild.Class
 
 instance MonadTrans (DynamicWriterT t w) where

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -22,6 +22,7 @@ import Reflex.Class
 import Reflex.Host.Class
 import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Class
+import Reflex.TriggerEvent.Class
 
 import Control.Lens
 import Control.Monad.Exception

--- a/src/Reflex/PerformEvent/Class.hs
+++ b/src/Reflex/PerformEvent/Class.hs
@@ -11,6 +11,7 @@
 module Reflex.PerformEvent.Class where
 
 import Reflex.Class
+import Reflex.TriggerEvent.Class
 
 import Control.Monad.Identity
 import Control.Monad.Reader
@@ -21,12 +22,6 @@ class (Reflex t, Monad (Performable m), Monad m) => PerformEvent t m | m -> t wh
   type Performable m :: * -> *
   performEvent :: Event t (Performable m a) -> m (Event t a)
   performEvent_ :: Event t (Performable m ()) -> m ()
-
---TODO: Shouldn't have IO hard-coded
-class Monad m => TriggerEvent t m | m -> t where
-  newTriggerEvent :: m (Event t a, a -> IO ())
-  newTriggerEventWithOnComplete :: m (Event t a, a -> IO () -> IO ()) --TODO: This and newTriggerEvent should be unified somehow
-  newEventWithLazyTriggerWithOnComplete :: ((a -> IO () -> IO ()) -> IO (IO ())) -> m (Event t a)
 
 class (Reflex t, Monad m) => MonadRequest t m | m -> t where
   type Request m :: * -> *
@@ -48,11 +43,6 @@ instance PerformEvent t m => PerformEvent t (ReaderT r m) where
   performEvent e = do
     r <- ask
     lift $ performEvent $ flip runReaderT r <$> e
-
-instance TriggerEvent t m => TriggerEvent t (ReaderT r m) where
-  newTriggerEvent = lift newTriggerEvent
-  newTriggerEventWithOnComplete = lift newTriggerEventWithOnComplete
-  newEventWithLazyTriggerWithOnComplete = lift . newEventWithLazyTriggerWithOnComplete
 
 instance MonadRequest t m => MonadRequest t (ReaderT r m) where
   type Request (ReaderT r m) = Request m

--- a/src/Reflex/PostBuild/Class.hs
+++ b/src/Reflex/PostBuild/Class.hs
@@ -23,6 +23,7 @@ import qualified Data.Dependent.Map as DMap
 import Reflex.Class
 import Reflex.Host.Class
 import Reflex.PerformEvent.Class
+import Reflex.TriggerEvent.Class
 
 class (Reflex t, Monad m) => PostBuild t m | m -> t where
   getPostBuild :: m (Event t ())

--- a/src/Reflex/TriggerEvent/Base.hs
+++ b/src/Reflex/TriggerEvent/Base.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Reflex.TriggerEvent.Base where
+
+import Control.Concurrent
+import Control.Monad.Exception
+import Control.Monad.Reader
+import Control.Monad.Ref
+import Data.Dependent.Sum
+import Reflex.Class
+import Reflex.Host.Class
+import Reflex.PerformEvent.Base
+import Reflex.PerformEvent.Class
+import Reflex.PostBuild.Class
+import Reflex.TriggerEvent.Class
+
+data TriggerInvocation a = TriggerInvocation a (IO ())
+
+newtype TriggerEventT t m a = TriggerEventT
+  { unTriggerEventT :: ReaderT (Chan [DSum (EventTriggerRef t m) TriggerInvocation]) m a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadFix
+             , MonadIO
+             , MonadException
+             , MonadAsyncException
+             )
+
+runTriggerEventT :: TriggerEventT t m a -> Chan [DSum (EventTriggerRef t m) TriggerInvocation] -> m a
+runTriggerEventT = runReaderT . unTriggerEventT
+
+instance MonadTrans (TriggerEventT t) where
+  lift = TriggerEventT . lift
+
+instance PerformEvent t m =>
+         PerformEvent t (TriggerEventT t m) where
+  type Performable (TriggerEventT t m) = Performable m
+  performEvent_ e = lift $ performEvent_ e
+  {-# INLINABLE performEvent_ #-}
+  performEvent e = lift $ performEvent e
+  {-# INLINABLE performEvent #-}
+
+instance PostBuild t m =>
+         PostBuild t (TriggerEventT t m) where
+  getPostBuild = lift getPostBuild
+  {-# INLINABLE getPostBuild #-}
+
+instance MonadReflexCreateTrigger t m =>
+         MonadReflexCreateTrigger t (TriggerEventT t m) where
+  newEventWithTrigger = lift . newEventWithTrigger
+  {-# INLINABLE newEventWithTrigger #-}
+  newFanEventWithTrigger f = lift $ newFanEventWithTrigger f
+  {-# INLINABLE newFanEventWithTrigger #-}
+
+instance (Monad m, MonadRef m, Ref m ~ Ref IO, MonadReflexCreateTrigger t m) =>
+         TriggerEvent t (TriggerEventT t m) where
+  newTriggerEvent = do
+    (e, t) <- newTriggerEventWithOnComplete
+    return (e, \a -> t a $ return ())
+  {-# INLINABLE newTriggerEvent #-}
+  newTriggerEventWithOnComplete = do
+    events <- askEvents
+    (eResult, reResultTrigger) <- lift newEventWithTriggerRef
+    return . (,) eResult $ \a cb ->
+      writeChan events [EventTriggerRef reResultTrigger :=> TriggerInvocation a cb]
+  {-# INLINABLE newTriggerEventWithOnComplete #-}
+  newEventWithLazyTriggerWithOnComplete f = do
+    events <- askEvents
+    lift . newEventWithTrigger $ \t ->
+      f $ \a cb -> do
+        reResultTrigger <- newRef $ Just t
+        writeChan events [EventTriggerRef reResultTrigger :=> TriggerInvocation a cb]
+  {-# INLINABLE newEventWithLazyTriggerWithOnComplete #-}
+
+instance MonadRef m =>
+         MonadRef (TriggerEventT t m) where
+  type Ref (TriggerEventT t m) = Ref m
+  newRef = lift . newRef
+  {-# INLINABLE newRef #-}
+  readRef = lift . readRef
+  {-# INLINABLE readRef #-}
+  writeRef r = lift . writeRef r
+  {-# INLINABLE writeRef #-}
+
+instance MonadAtomicRef m =>
+         MonadAtomicRef (TriggerEventT t m) where
+  atomicModifyRef r = lift . atomicModifyRef r
+  {-# INLINABLE atomicModifyRef #-}
+
+instance MonadSample t m =>
+         MonadSample t (TriggerEventT t m) where
+  sample = lift . sample
+  {-# INLINABLE sample #-}
+
+instance MonadHold t m =>
+         MonadHold t (TriggerEventT t m) where
+  hold v0 v' = lift $ hold v0 v'
+  {-# INLINABLE hold #-}
+  holdDyn v0 v' = lift $ holdDyn v0 v'
+  {-# INLINABLE holdDyn #-}
+  holdIncremental v0 v' = lift $ holdIncremental v0 v'
+  {-# INLINABLE holdIncremental #-}
+
+askEvents
+  :: Monad m
+  => TriggerEventT t m (Chan [DSum (EventTriggerRef t m) TriggerInvocation])
+askEvents = TriggerEventT ask

--- a/src/Reflex/TriggerEvent/Class.hs
+++ b/src/Reflex/TriggerEvent/Class.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Reflex.TriggerEvent.Class where
+
+import Reflex.Class
+
+import Control.Monad.Reader
+
+--TODO: Shouldn't have IO hard-coded
+class Monad m => TriggerEvent t m | m -> t where
+  newTriggerEvent :: m (Event t a, a -> IO ())
+  newTriggerEventWithOnComplete :: m (Event t a, a -> IO () -> IO ()) --TODO: This and newTriggerEvent should be unified somehow
+  newEventWithLazyTriggerWithOnComplete :: ((a -> IO () -> IO ()) -> IO (IO ())) -> m (Event t a)
+
+instance TriggerEvent t m => TriggerEvent t (ReaderT r m) where
+  newTriggerEvent = lift newTriggerEvent
+  newTriggerEventWithOnComplete = lift newTriggerEventWithOnComplete
+  newEventWithLazyTriggerWithOnComplete = lift . newEventWithLazyTriggerWithOnComplete
+


### PR DESCRIPTION
This pull request adds a base monad `ReflexBase` capable of most of the functionality offered by the various Reflex typeclasses. In particular, it uses `PerformEventT` and `PostBuildT` to enable their corresponding typeclasses, and it uses a new `TriggerEventT` monad transformer for the `TriggerEvent` class. The motivation of this pull request is to enable users of `reflex` to write reactive programs in contexts other than web apps with the same relative ease. Having one monad with these three main classes on top of `SpiderHost` covers a large surface area of requirements.

`TriggerEventT` was factored out of `ImmediateDomBuilder` from `reflex-dom`. As such, much of the `Widget` monad can be replaced with `ReflexBase`. This includes most of the implementation of `attachWidget`, which was factored out into `runReflexBase`. I haven't changed `reflex-dom` to make use of this refactoring, but it shouldn't be difficult.

There is one breaking change. The `TriggerEvent` class now exists in its own module, instead of sitting in the `Reflex.PerformEvent.Class` module. This is for clarity, not a requirement.