### PR TITLE
Move travis to use nix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ cache:
     - /nix
 matrix:
   include:
-  - env: COMPILER=ghc784
   - env: COMPILER=ghc7103
   - env: COMPILER=ghc801
   - env: COMPILER=ghcjs
 script:
+  - set -e
   - nix-build -E "with (import <nixpkgs> {}); pkgs.haskell.packages.$COMPILER.callPackage ./default.nix { }"
   - nix-collect-garbage -d # This is important to do right before 'script' ends so the cache gets GCed
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
     - /nix
 matrix:
   include:
+  - env: COMPILER=ghc784
+  - env: COMPILER=ghc7103
   - env: COMPILER=ghc801
   - env: COMPILER=ghcjs
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,12 @@
-sudo: false
-before_install:
-  - travis_retry cabal-$CABALVER update
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH
-install:
-  - travis_retry cabal-$CABALVER install --only-dependencies -j --enable-tests
-script:
-  - cabal-$CABALVER configure -v2 --enable-tests
-  - travis_wait cabal-$CABALVER build
-  - cabal-$CABALVER test
-  - cabal-$CABALVER sdist   # tests that a source-distribution can be generated
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
-  - SRC_TGZ=$(cabal-$CABALVER info . | awk '{print $2;exit}').tar.gz &&
-    (cd dist && cabal-$CABALVER install --force-reinstalls "$SRC_TGZ")
-
+language: nix
+cache:
+  directories:
+    - /nix
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.18, ghc-7.8.4, alex-3.1.4, happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.1
-      addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.1, alex-3.1.4, happy-1.19.5],sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1
-      addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1, alex-3.1.4, happy-1.19.5],sources: [hvr-ghc]}}
-  fast_finish: true
+  - env: COMPILER=ghc801
+  - env: COMPILER=ghcjs
+script:
+  - nix-build -E "with (import <nixpkgs> {}); pkgs.haskell.packages.$COMPILER.callPackage ./default.nix { }"
+  - nix-collect-garbage -d # This is important to do right before 'script' ends so the cache gets GCed
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Cache Buster: 0
 language: nix
 cache:
   directories:


### PR DESCRIPTION
Travis now builds. This pr removes support for ghc 7.8.4 but adds support for ghcjs! The travis file is also significantly easier to read.