### PR TITLE
Fix build against new versions of haskell-src-{exts,meta}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 cabal.sandbox.config
 .cabal-sandbox/
+.stack-work/
 dist-*
 cabal-dev
 *.o

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -107,8 +107,8 @@ library
     cpp-options: -DUSE_TEMPLATE_HASKELL
     build-depends:
       dependent-sum >= 0.3 && < 0.5,
-      haskell-src-exts >= 1.16 && < 1.18,
-      haskell-src-meta == 0.6.*,
+      haskell-src-exts >= 1.17 && < 1.19,
+      haskell-src-meta >= 0.6,
       template-haskell >= 2.9 && < 2.12
     exposed-modules:
       Reflex.Dynamic.TH

--- a/src/Reflex/Dynamic/TH.hs
+++ b/src/Reflex/Dynamic/TH.hs
@@ -89,10 +89,10 @@ mkDynExp s = case Hs.parseExpWithMode (Hs.defaultParseMode { Hs.extensions = [ H
   Hs.ParseOk e -> qDynPure $ return $ everywhere (id `extT` reinstateUnqDyn) $ Hs.toExp $ everywhere (id `extT` antiE) e
     where TH.Name (TH.OccName occName) (TH.NameG _ _ (TH.ModName modName)) = 'unqMarker
           antiE x = case x of
-            Hs.SpliceExp se ->
-              Hs.App (Hs.Var $ Hs.Qual (Hs.ModuleName modName) (Hs.Ident occName)) $ case se of
-                Hs.IdSplice v -> Hs.Var $ Hs.UnQual $ Hs.Ident v
-                Hs.ParenSplice ps -> ps
+            Hs.SpliceExp _ se ->
+              Hs.App Hs.noLoc (Hs.Var Hs.noLoc $ Hs.Qual Hs.noLoc (Hs.ModuleName Hs.noLoc modName) (Hs.Ident Hs.noLoc occName)) $ case se of
+                Hs.IdSplice _ v -> Hs.Var Hs.noLoc $ Hs.UnQual Hs.noLoc $ Hs.Ident Hs.noLoc v
+                Hs.ParenSplice _ ps -> ps
             _ -> x
           reinstateUnqDyn (TH.Name (TH.OccName occName') (TH.NameQ (TH.ModName modName')))
             | modName == modName' && occName == occName' = 'unqMarker

--- a/src/Reflex/Patch.hs
+++ b/src/Reflex/Patch.hs
@@ -205,7 +205,7 @@ mapEditSetMoved moved = \case
 --   * The same source key may not be moved to two destination keys.
 --   * Any key that is the source of a Move must also be edited
 --     (otherwise, the Move would duplicate it)
-data PatchMapWithMove k v = PatchMapWithMove (Map k (MapEdit k v)) deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+newtype PatchMapWithMove k v = PatchMapWithMove (Map k (MapEdit k v)) deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 unPatchMapWithMove :: PatchMapWithMove k v -> Map k (MapEdit k v)
 unPatchMapWithMove (PatchMapWithMove p) = p

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}

--- a/test/GC.hs
+++ b/test/GC.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, GADTs, TypeFamilies, RankNTypes, ScopedTypeVariables, LambdaCase #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, GADTs, TypeFamilies, RankNTypes, ScopedTypeVariables #-}
 module Main where
 
 import Control.Monad

--- a/test/Reflex/Test/CrossImpl.hs
+++ b/test/Reflex/Test/CrossImpl.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE RankNTypes #-}


### PR DESCRIPTION
Validation results:
```
Running 6 test suites...
Test suite semantics: RUNNING...
Test suite semantics: PASS
Test suite logged to: dist/test/reflex-0.5.0-semantics.log
Test suite hlint: RUNNING...
./src/Reflex/Patch.hs:208:1: Suggestion: Use newtype instead of data
Found:
  data PatchMapWithMove k v = PatchMapWithMove (Map k (MapEdit k v))
                            deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
Why not:
  newtype PatchMapWithMove k v = PatchMapWithMove (Map k
                                                     (MapEdit k v))
                               deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
Note: decreases laziness

./src/Reflex/Spider/Internal.hs:11:1: Warning: Unused LANGUAGE pragma
Found:
  {-# LANGUAGE LambdaCase #-}
Why not remove it.

./test/GC.hs:1:1: Warning: Unused LANGUAGE pragma
Found:
  {-# LANGUAGE OverloadedStrings, FlexibleContexts, GADTs,
    TypeFamilies, RankNTypes, ScopedTypeVariables, LambdaCase #-}
Why not:
  {-# LANGUAGE OverloadedStrings, FlexibleContexts, GADTs,
    TypeFamilies, RankNTypes, ScopedTypeVariables #-}

./test/Reflex/Test/CrossImpl.hs:7:1: Warning: Unused LANGUAGE pragma
Found:
  {-# LANGUAGE LambdaCase #-}
Why not remove it.

4 hints (72 ignored)
Test suite hlint: FAIL
Test suite logged to: dist/test/reflex-0.5.0-hlint.log
Test suite EventWriterT: RUNNING...
Test suite EventWriterT: PASS
Test suite logged to: dist/test/reflex-0.5.0-EventWriterT.log
Test suite RequesterT: RUNNING...
Test suite RequesterT: PASS
Test suite logged to: dist/test/reflex-0.5.0-RequesterT.log
Test suite GC-Semantics: RUNNING...
Test suite GC-Semantics: PASS
Test suite logged to: dist/test/reflex-0.5.0-GC-Semantics.log
Test suite rootCleanup: RUNNING...
Test suite rootCleanup: PASS
Test suite logged to: dist/test/reflex-0.5.0-rootCleanup.log
5 of 6 test suites (5 of 6 test cases) passed.
```