### PR TITLE
Fixes a typo in the docs for `<@>`.

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -950,7 +950,7 @@ infixl 4 <@>
 --
 -- A more suggestive example might be:
 --
--- > handleMouse <$> bPlayerState <*> bMousePosition <*> eMouseClick :: Event t (GameState -> GameState)
+-- > handleMouse <$> bPlayerState <*> bMousePosition <@> eMouseClick :: Event t (GameState -> GameState)
 --
 (<@>) :: Reflex t => Behavior t (a -> b) -> Event t a -> Event t b
 (<@>) b = push $ \x -> do


### PR DESCRIPTION
Thanks to @luigy for pointing this out.