### PR TITLE
Fix a QueryT bug and along the way improve the test infrastructure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 , monad-control, mtl, primitive, ref-tf, semigroupoids
 , semigroups, split, stdenv, stm, syb, template-haskell
 , these, transformers, transformers-compat, prim-uniq
-, data-default
+, data-default, filepath, directory, filemanip
 , useTemplateHaskell ? true
 }:
 mkDerivation {
@@ -23,7 +23,7 @@ mkDerivation {
     haskell-src-exts haskell-src-meta
   ]);
   testHaskellDepends = if ghc.isGhcjs or false then [] else [
-    hlint
+    hlint filepath directory filemanip
   ];
   configureFlags = if useTemplateHaskell then [] else [
     "-f-use-template-haskell"

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -189,6 +189,8 @@ test-suite EventWriterT
   hs-source-dirs: test
   build-depends: base
                , dependent-sum
+               , lens
+               , these
                , transformers
                , reflex
                , ref-tf
@@ -200,6 +202,8 @@ test-suite RequesterT
   build-depends: base
                , dependent-sum
                , dependent-map
+               , lens
+               , these
                , transformers
                , reflex
                , ref-tf

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -175,7 +175,11 @@ test-suite hlint
   type: exitcode-stdio-1.0
   main-is: hlint.hs
   hs-source-dirs: test
-  build-depends: base, hlint == 1.9.*
+  build-depends: base
+               , directory
+               , filepath
+               , filemanip
+               , hlint == 1.9.*
   if impl(ghcjs)
     buildable: False
 

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -208,6 +208,20 @@ test-suite RequesterT
                , reflex
                , ref-tf
 
+test-suite QueryT
+  type: exitcode-stdio-1.0
+  main-is: QueryT.hs
+  hs-source-dirs: test
+  build-depends: base
+               , containers
+               , dependent-sum
+               , dependent-map
+               , lens
+               , these
+               , transformers
+               , reflex
+               , ref-tf
+
 test-suite GC-Semantics
   type: exitcode-stdio-1.0
   main-is: GC.hs

--- a/test/EventWriterT.hs
+++ b/test/EventWriterT.hs
@@ -9,21 +9,14 @@ import Reflex
 import Reflex.EventWriter
 import Test.Run
 
-import System.Exit (exitFailure)
-
-import Data.IORef
-import Control.Monad.Ref
-import Reflex.Host.Class
-import Data.List
-
 main :: IO ()
 main = do
-  os1@[[Just [10,9,8,7,6,5,4,3,2,1]]] <- runApp' (unwrapApp app1) $
+  os1@[[Just [10,9,8,7,6,5,4,3,2,1]]] <- runApp' (unwrapApp testOrdering) $
     [ Just ()
     ]
   print os1
   os2@[[Just [1,3,5,7,9]],[Nothing,Nothing],[Just [2,4,6,8,10]],[Just [2,4,6,8,10],Nothing]]
-    <- runApp' (unwrapApp app2) $ map Just $
+    <- runApp' (unwrapApp testSimultaneous) $ map Just $
          [ This ()
          , That ()
          , This ()
@@ -37,13 +30,13 @@ unwrapApp x appIn = do
   ((), e) <- runEventWriterT $ x appIn
   return e
 
-app1 :: (Reflex t, Monad m) => Event t () -> EventWriterT t [Int] m ()
-app1 pulse = do
+testOrdering :: (Reflex t, Monad m) => Event t () -> EventWriterT t [Int] m ()
+testOrdering pulse = do
   forM_ [10,9..1] $ \i -> tellEvent ([i] <$ pulse)
   return ()
 
-app2 :: (Reflex t, MonadAdjust t m, MonadHold t m) => Event t (These () ()) -> EventWriterT t [Int] m ()
-app2 pulse = do
+testSimultaneous :: (Reflex t, MonadAdjust t m, MonadHold t m) => Event t (These () ()) -> EventWriterT t [Int] m ()
+testSimultaneous pulse = do
   let e0 = fmapMaybe (^? here) pulse
       e1 = fmapMaybe (^? there) pulse
   forM_ [1,3..9] $ \i -> runWithReplace (tellEvent ([i] <$ e0)) $ ffor e1 $ \_ -> tellEvent ([i+1] <$ e0)

--- a/test/EventWriterT.hs
+++ b/test/EventWriterT.hs
@@ -13,41 +13,20 @@ import Reflex
 import Reflex.EventWriter
 import Reflex.Host.Class
 import Reflex.PerformEvent.Base
+import Test.Run
 
 import System.Exit (exitFailure)
 
+
 main :: IO ()
 main = do
-  (Just out1, Nothing) <- runApp app1
+  (Just out1, Nothing) <- runApp $ runEventWriterT . app1
   print out1
-  (Just out2, Just (out3, out4)) <- runApp app2
+  (Just out2, Just (out3, out4)) <- runApp $ runEventWriterT . app2
   print out2
   print out3
   print out4
   when (sort out1 /= out1 || map (+1) out2 /= out3 || out3 /= out4) exitFailure
-
-runApp :: (Show a, t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-       => (Event t () -> EventWriterT t [a] (PerformEventT t m) (Maybe (Ref m (Maybe (EventTrigger t ())))))
-       -> IO (Maybe [a], Maybe ([a], [a]))
-runApp x = runSpiderHost $ do
-  (pulseE, pulseTriggerRef) <- newEventWithTriggerRef
-  ((mactuateRef, e), FireCommand fire) <- hostPerformEventT $ runEventWriterT (x pulseE)
-  hnd <- subscribeEvent e
-  out1 <- fireEventRefAndRead pulseTriggerRef () hnd
-  out2 <- fmap join $ forM mactuateRef $ \actuateRef -> do
-    let readPhase = do
-          mGetValue <- readEvent hnd
-          case mGetValue of
-            Nothing -> return Nothing
-            Just getValue -> fmap Just getValue
-    mactuate <- readRef actuateRef
-    mpulse <- readRef pulseTriggerRef
-    forM ((,) <$> mactuate <*> mpulse) $ \(actuate, pulse) -> do
-      _ <- fire [actuate :=> Identity ()] $ return ()
-      [Just a] <- fire [pulse :=> Identity ()] $ readPhase
-      [Just b, Nothing] <- fire [actuate :=> Identity (), pulse :=> Identity ()] $ readPhase
-      return (a,b)
-  return (out1, out2)
 
 app1 :: (Reflex t, Ref m ~ IORef, EventWriter t [Int] m) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
 app1 e = do

--- a/test/EventWriterT.hs
+++ b/test/EventWriterT.hs
@@ -1,40 +1,51 @@
 {-# LANGUAGE FlexibleContexts, GADTs #-}
 module Main where
 
+import Control.Lens
 import Control.Monad
-import Control.Monad.IO.Class
-import Control.Monad.Ref
-import Data.Dependent.Sum
-import Data.IORef
-import Data.List
-import Data.Functor.Identity
+import Data.These
 
 import Reflex
 import Reflex.EventWriter
-import Reflex.Host.Class
-import Reflex.PerformEvent.Base
 import Test.Run
 
 import System.Exit (exitFailure)
 
+import Data.IORef
+import Control.Monad.Ref
+import Reflex.Host.Class
+import Data.List
 
 main :: IO ()
 main = do
-  (Just out1, Nothing) <- runApp $ runEventWriterT . app1
-  print out1
-  (Just out2, Just (out3, out4)) <- runApp $ runEventWriterT . app2
-  print out2
-  print out3
-  print out4
-  when (sort out1 /= out1 || map (+1) out2 /= out3 || out3 /= out4) exitFailure
+  os1@[[Just [10,9,8,7,6,5,4,3,2,1]]] <- runApp' (unwrapApp app1) $
+    [ Just ()
+    ]
+  print os1
+  os2@[[Just [1,3,5,7,9]],[Nothing,Nothing],[Just [2,4,6,8,10]],[Just [2,4,6,8,10],Nothing]]
+    <- runApp' (unwrapApp app2) $ map Just $
+         [ This ()
+         , That ()
+         , This ()
+         , These () ()
+         ]
+  print os2
+  return ()
 
-app1 :: (Reflex t, Ref m ~ IORef, EventWriter t [Int] m) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
-app1 e = do
-  forM_ [1..10] $ \i -> tellEvent ([i] <$ e)
-  return Nothing
+unwrapApp :: (Reflex t, Monad m) => (a -> EventWriterT t [Int] m ()) -> a -> m (Event t [Int])
+unwrapApp x appIn = do
+  ((), e) <- runEventWriterT $ x appIn
+  return e
 
-app2 :: (Reflex t, Ref m ~ IORef, EventWriter t [Int] m, MonadAdjust t m, MonadReflexCreateTrigger t m, MonadRef m) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
-app2 e = do
-  (pulse, pulseTriggerRef) <- newEventWithTriggerRef
-  forM_ [1,3..9] $ \i -> runWithReplace (tellEvent ([i] <$ e)) $ ffor pulse $ \_ -> tellEvent ([i+1] <$ e)
-  return (Just pulseTriggerRef)
+app1 :: (Reflex t, Monad m) => Event t () -> EventWriterT t [Int] m ()
+app1 pulse = do
+  forM_ [10,9..1] $ \i -> tellEvent ([i] <$ pulse)
+  return ()
+
+app2 :: (Reflex t, MonadAdjust t m, MonadHold t m) => Event t (These () ()) -> EventWriterT t [Int] m ()
+app2 pulse = do
+  let e0 = fmapMaybe (^? here) pulse
+      e1 = fmapMaybe (^? there) pulse
+  forM_ [1,3..9] $ \i -> runWithReplace (tellEvent ([i] <$ e0)) $ ffor e1 $ \_ -> tellEvent ([i+1] <$ e0)
+  return ()
+

--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -4,15 +4,21 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 import Control.Lens
 import Control.Monad.Fix
 import Data.Align
-import qualified Data.AppendMap as Map
+import Data.AppendMap (AppendMap)
+import qualified Data.AppendMap as AMap
+import Data.Functor.Misc
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Semigroup
 import Data.These
 
 import Reflex
+import Reflex.Patch.MapWithMove
 import Test.Run
 
 newtype MyQuery = MyQuery SelectedCount
@@ -26,7 +32,7 @@ instance (Ord k, Query a, Eq (QueryResult a)) => Query (Selector k a) where
   type QueryResult (Selector k a) = Selector k (QueryResult a)
   crop q r = undefined
 
-newtype Selector k a = Selector { unSelector :: Map.AppendMap k a }
+newtype Selector k a = Selector { unSelector :: AppendMap k a }
   deriving (Show, Read, Eq, Ord, Functor)
 
 instance (Ord k, Eq a, Monoid a) => Semigroup (Selector k a) where
@@ -40,7 +46,7 @@ instance (Ord k, Eq a, Monoid a) => Semigroup (Selector k a) where
           in if z == mempty then Nothing else Just z
 
 instance (Ord k, Eq a, Monoid a) => Monoid (Selector k a) where
-  mempty = Selector Map.empty
+  mempty = Selector AMap.empty
   mappend = (<>)
 
 instance (Eq a, Ord k, Group a) => Group (Selector k a) where
@@ -50,25 +56,85 @@ instance (Eq a, Ord k, Group a) => Additive (Selector k a)
 
 main :: IO ()
 main = do
-  [0, 1, 1, 0] <- fmap (map fst . concat) $ runApp app () $ map (Just . That) $
-    [ That ()
-    , This ()
-    , That ()
-    ]
+  [0, 1, 1, 0] <- fmap (map fst . concat) $
+    runApp (testQueryT testRunWithReplace) () $ map (Just . That) $
+      [ That (), This (), That () ]
+  [0, 1, 1, 0] <- fmap (map fst . concat) $
+    runApp (testQueryT testSequenceDMapWithAdjust) () $ map (Just . That) $
+      [ That (), This (), That () ]
+  [0, 1, 1, 0] <- fmap (map fst . concat) $
+    runApp (testQueryT testSequenceDMapWithAdjustWithMove) () $ map (Just . That) $
+      [ That (), This (), That () ]
   return ()
 
-app :: (Reflex t, MonadHold t m, MonadAdjust t m, MonadFix m)
-    =>  AppIn t () (These () ())
-    -> m (AppOut t Int Int)
-app (AppIn _ pulse) = do
+testQueryT :: (Reflex t, MonadFix m)
+           => (Event t () -> Event t () -> QueryT t (Selector Int MyQuery) m ())
+           -> AppIn t () (These () ())
+           -> m (AppOut t Int Int)
+testQueryT w (AppIn _ pulse) = do
   let replace = fmapMaybe (^? here) pulse
       increment = fmapMaybe (^? there) pulse
-      w = do
-        n <- count increment
-        queryDyn $ zipDynWith (\x y -> Selector (Map.singleton (x :: Int) y)) n $ pure $ MyQuery $ SelectedCount 1
-  (_, q) <- runQueryT (runWithReplace w $ w <$ replace) $ pure mempty
-  let qDyn = fmap (head . Map.keys . unSelector) $ incrementalToDynamic q
+  (_, q) <- runQueryT (w replace increment) $ pure mempty
+  let qDyn = head . AMap.keys . unSelector <$> incrementalToDynamic q
   return $ AppOut
     { _appOut_behavior = current qDyn
     , _appOut_event = updated qDyn
     }
+
+testRunWithReplace :: ( Reflex t
+                      , MonadAdjust t m
+                      , MonadHold t m
+                      , MonadFix m
+                      , MonadQuery t (Selector Int MyQuery) m)
+                   => Event t ()
+                   -> Event t ()
+                   -> m ()
+testRunWithReplace replace increment = do
+  let w = do
+        n <- count increment
+        queryDyn $ zipDynWith (\x y -> Selector (AMap.singleton (x :: Int) y)) n $ pure $ MyQuery $ SelectedCount 1
+  _ <- runWithReplace w $ w <$ replace
+  return ()
+
+testSequenceDMapWithAdjust :: ( Reflex t
+                              , MonadAdjust t m
+                              , MonadHold t m
+                              , MonadFix m
+                              , MonadQuery t (Selector Int MyQuery) m)
+                           => Event t ()
+                           -> Event t ()
+                           -> m ()
+testSequenceDMapWithAdjust replace increment = do
+  _ <- listHoldWithKey (Map.singleton () ()) (Map.singleton () (Just ()) <$ replace) $ \_ _ -> do
+    n <- count increment
+    queryDyn $ zipDynWith (\x y -> Selector (AMap.singleton (x :: Int) y)) n $ pure $ MyQuery $ SelectedCount 1
+  return ()
+
+testSequenceDMapWithAdjustWithMove :: ( Reflex t
+                                      , MonadAdjust t m
+                                      , MonadHold t m
+                                      , MonadFix m
+                                      , MonadQuery t (Selector Int MyQuery) m)
+                                   => Event t ()
+                                   -> Event t ()
+                                   -> m ()
+testSequenceDMapWithAdjustWithMove replace increment = do
+  _ <- listHoldWithKeyWithMove (Map.singleton () ()) (Map.singleton () (Just ()) <$ replace) $ \_ _ -> do
+    n <- count increment
+    queryDyn $ zipDynWith (\x y -> Selector (AMap.singleton (x :: Int) y)) n $ pure $ MyQuery $ SelectedCount 1
+  return ()
+
+listHoldWithKey :: forall t m k v a. (Ord k, MonadHold t m, MonadAdjust t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> m a) -> m (Dynamic t (Map k a))
+listHoldWithKey m0 m' f = do
+  let dm0 = mapWithFunctorToDMap $ Map.mapWithKey f m0
+      dm' = fmap (PatchDMap . mapWithFunctorToDMap . Map.mapWithKey (\k v -> ComposeMaybe $ fmap (f k) v)) m'
+  (a0, a') <- sequenceDMapWithAdjust dm0 dm'
+  fmap dmapToMap . incrementalToDynamic <$> holdIncremental a0 a'
+
+
+-- scam it out to test traverseDMapWithAdjustWithMove
+listHoldWithKeyWithMove :: forall t m k v a. (Ord k, MonadHold t m, MonadAdjust t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> m a) -> m (Dynamic t (Map k a))
+listHoldWithKeyWithMove m0 m' f = do
+  (n0, n') <- mapMapWithAdjustWithMove f m0 $ ffor m' $ PatchMapWithMove . Map.map (\v -> NodeInfo (maybe From_Delete From_Insert v) Nothing)
+  incrementalToDynamic <$> holdIncremental n0 n'
+-- -}

--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -1,8 +1,16 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+import Data.Align
 import qualified Data.AppendMap as Map
 import Data.Semigroup
-import Reflex.Dom
+import Data.These
+
+import Reflex
+import Test.Run
 
 newtype MyQuery = MyQuery SelectedCount
   deriving (Show, Read, Eq, Ord, Monoid, Semigroup, Additive, Group)
@@ -11,16 +19,38 @@ instance Query MyQuery where
   type QueryResult MyQuery = ()
   crop _ _ = ()
 
-instance (Ord k, Query a) => Query (Map.AppendMap k a) where
-  type QueryResult (Map.AppendMap k a) = Map.AppendMap k (QueryResult a)
+instance (Ord k, Query a, Eq (QueryResult a)) => Query (Selector k a) where
+  type QueryResult (Selector k a) = Selector k (QueryResult a)
   crop q r = undefined
+
+newtype Selector k a = Selector { unSelector :: Map.AppendMap k a }
+  deriving (Show, Read, Eq, Ord, Functor)
+
+instance (Ord k, Eq a, Monoid a) => Semigroup (Selector k a) where
+  (Selector a) <> (Selector b) = Selector $ fmapMaybe id $ f a b
+    where
+      f = alignWith $ \case
+        This x -> Just x
+        That y -> Just y
+        These x y ->
+          let z = x `mappend` y
+          in if z == mempty then Nothing else Just z
+
+instance (Ord k, Eq a, Monoid a) => Monoid (Selector k a) where
+  mempty = Selector Map.empty
+  mappend = (<>)
+
+instance (Eq a, Ord k, Group a) => Group (Selector k a) where
+  negateG = fmap negateG
+
+instance (Eq a, Ord k, Group a) => Additive (Selector k a)
 
 main :: IO ()
 main = mainWidget $ do
   let w = do
         n <- count =<< button "Increment"
         display n
-        queryDyn $ zipDynWith Map.singleton n $ pure $ MyQuery $ SelectedCount 1
+        queryDyn $ zipDynWith (\x y -> Selector (Map.singleton (x :: Int) y)) n $ pure $ MyQuery $ SelectedCount 1
         return ()
       outer = do
         replace <- button "Replace"

--- a/test/RequesterT.hs
+++ b/test/RequesterT.hs
@@ -1,62 +1,65 @@
 {-# LANGUAGE FlexibleContexts, GADTs, RankNTypes, ScopedTypeVariables #-}
 module Main where
 
+import Control.Lens
 import Control.Monad
-import Control.Monad.IO.Class
-import Control.Monad.Ref
 import qualified Data.Dependent.Map as DMap
 import Data.Dependent.Sum
-import Data.IORef
-import Data.List
-import Data.Functor.Identity
+import Data.These
 
 import Reflex
-import Reflex.Host.Class
-import Reflex.PerformEvent.Base
 import Reflex.Requester.Base
 import Reflex.Requester.Class
 import Test.Run
-
-import System.Exit (exitFailure, exitSuccess)
 
 data RequestInt a where
   RequestInt :: Int -> RequestInt Int
 
 main :: IO ()
 main = do
+  os1@[[Just [10,9,8,7,6,5,4,3,2,1]]] <- runApp' (unwrapApp testOrdering) $
+    [ Just ()
+    ]
+  print os1
+  os2@[[Just [1,3,5,7,9]],[Nothing,Nothing],[Just [2,4,6,8,10]],[Just [2,4,6,8,10],Nothing]]
+    <- runApp' (unwrapApp testSimultaneous) $ map Just $
+         [ This ()
+         , That ()
+         , This ()
+         , These () ()
+         ]
+  print os2
   return ()
-
-{-
-
-main :: IO ()
-main = do
-  (Just out1, Nothing) <- runApp $ unwrapApp app1
-  print out1
-  (Just out2, Just (out3, out4)) <- runApp $ unwrapApp app2
-  print out2
-  print out3
-  print out4
-  when (sort out1 /= out1 || map (+1) out2 /= out3 || out3 /= out4) exitFailure
 
 unwrapRequest :: DSum tag RequestInt -> Int
 unwrapRequest (_ :=> RequestInt i) = i
 
-unwrapApp :: forall x t a response. (Reflex t, ReflexHost t)
-          => (x -> RequesterT t RequestInt response (PerformEventT t (SpiderHost Global)) a)
-          -> x -> PerformEventT t (SpiderHost Global) (a, Event t [Int])
-unwrapApp x e = do
-  (a, b) <- runRequesterT (x e) never
-  return (a, fmap (map unwrapRequest . DMap.toList) b)
+unwrapApp :: ( Reflex t, Monad m )
+          => (a -> RequesterT t RequestInt Identity m ())
+          -> a
+          -> m (Event t [Int])
+unwrapApp x appIn = do
+  ((), e) <- runRequesterT (x appIn) never
+  return $ fmap (map unwrapRequest . DMap.toList) e
 
-app1 :: (Reflex t, Ref m ~ IORef, Requester t m, Response m ~ Identity, Request m ~ RequestInt) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
-app1 e = do
-  forM_ [1..10] $ \i -> requestingIdentity (RequestInt i <$ e)
-  return Nothing
+testOrdering :: ( Response m ~ Identity
+                , Request m ~ RequestInt
+                , Requester t m
+                , MonadAdjust t m)
+             => Event t ()
+             -> m ()
+testOrdering pulse = do
+  forM_ [10,9..1] $ \i -> requestingIdentity (RequestInt i <$ pulse)
+  return ()
 
-app2 :: (Reflex t, Ref m ~ IORef, Requester t m, Response m ~ Identity, Request m ~ RequestInt, MonadAdjust t m, MonadReflexCreateTrigger t m, MonadRef m) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
-app2 e = do
-  (pulse, pulseTriggerRef) <- newEventWithTriggerRef
-  forM_ [1,3..9] $ \i -> runWithReplace (requestingIdentity (RequestInt i <$ e)) $ ffor pulse $ \_ -> requestingIdentity (RequestInt (i+1) <$ e)
-  return (Just pulseTriggerRef)
-
--}
+testSimultaneous :: ( Response m ~ Identity
+                    , Request m ~ RequestInt
+                    , Requester t m
+                    , MonadAdjust t m)
+                 => Event t (These () ())
+                 -> m ()
+testSimultaneous pulse = do
+  let tellE = fmapMaybe (^? here) pulse
+      switchE = fmapMaybe (^? there) pulse
+  forM_ [1,3..9] $ \i -> runWithReplace (requestingIdentity (RequestInt i <$ tellE)) $ ffor switchE $ \_ ->
+    requestingIdentity (RequestInt (i+1) <$ tellE)

--- a/test/RequesterT.hs
+++ b/test/RequesterT.hs
@@ -24,6 +24,12 @@ data RequestInt a where
 
 main :: IO ()
 main = do
+  return ()
+
+{-
+
+main :: IO ()
+main = do
   (Just out1, Nothing) <- runApp $ unwrapApp app1
   print out1
   (Just out2, Just (out3, out4)) <- runApp $ unwrapApp app2
@@ -53,3 +59,4 @@ app2 e = do
   forM_ [1,3..9] $ \i -> runWithReplace (requestingIdentity (RequestInt i <$ e)) $ ffor pulse $ \_ -> requestingIdentity (RequestInt (i+1) <$ e)
   return (Just pulseTriggerRef)
 
+-}

--- a/test/RequesterT.hs
+++ b/test/RequesterT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, GADTs #-}
+{-# LANGUAGE FlexibleContexts, GADTs, RankNTypes, ScopedTypeVariables #-}
 module Main where
 
 import Control.Monad
@@ -15,6 +15,7 @@ import Reflex.Host.Class
 import Reflex.PerformEvent.Base
 import Reflex.Requester.Base
 import Reflex.Requester.Class
+import Test.Run
 
 import System.Exit (exitFailure, exitSuccess)
 
@@ -23,39 +24,23 @@ data RequestInt a where
 
 main :: IO ()
 main = do
-  (Just out1, Nothing) <- runApp app1
+  (Just out1, Nothing) <- runApp $ unwrapApp app1
   print out1
-  (Just out2, Just (out3, out4)) <- runApp app2
+  (Just out2, Just (out3, out4)) <- runApp $ unwrapApp app2
   print out2
   print out3
   print out4
   when (sort out1 /= out1 || map (+1) out2 /= out3 || out3 /= out4) exitFailure
 
-runApp :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-       => (Event t () -> RequesterT t RequestInt Identity (PerformEventT t m) (Maybe (Ref m (Maybe (EventTrigger t ())))))
-       -> IO (Maybe [Int], Maybe ([Int], [Int]))
-runApp x = runSpiderHost $ do
-  (pulseE, pulseTriggerRef) <- newEventWithTriggerRef
-  ((mactuateRef, e), FireCommand fire) <- hostPerformEventT $ runRequesterT (x pulseE) never
-  hnd <- subscribeEvent (map unwrapRequest . DMap.toList <$> e)
-  out1 <- fireEventRefAndRead pulseTriggerRef () hnd
-  out2 <- fmap join $ forM mactuateRef $ \actuateRef -> do
-    let readPhase = do
-          mGetValue <- readEvent hnd
-          case mGetValue of
-            Nothing -> return Nothing
-            Just getValue -> fmap Just getValue
-    mactuate <- readRef actuateRef
-    mpulse <- readRef pulseTriggerRef
-    forM ((,) <$> mactuate <*> mpulse) $ \(actuate, pulse) -> do
-      _ <- fire [actuate :=> Identity ()] $ return ()
-      [Just a] <- fire [pulse :=> Identity ()] $ readPhase
-      [Just b, Nothing] <- fire [actuate :=> Identity (), pulse :=> Identity ()] $ readPhase
-      return (a,b)
-  return (out1, out2)
-
 unwrapRequest :: DSum tag RequestInt -> Int
 unwrapRequest (_ :=> RequestInt i) = i
+
+unwrapApp :: forall x t a response. (Reflex t, ReflexHost t)
+          => (x -> RequesterT t RequestInt response (PerformEventT t (SpiderHost Global)) a)
+          -> x -> PerformEventT t (SpiderHost Global) (a, Event t [Int])
+unwrapApp x e = do
+  (a, b) <- runRequesterT (x e) never
+  return (a, fmap (map unwrapRequest . DMap.toList) b)
 
 app1 :: (Reflex t, Ref m ~ IORef, Requester t m, Response m ~ Identity, Request m ~ RequestInt) => Event t () -> m (Maybe (Ref m (Maybe (EventTrigger t ()))))
 app1 e = do

--- a/test/Test/Run.hs
+++ b/test/Test/Run.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE GADTs #-}
+module Test.Run where
+
+import Control.Monad
+import Control.Monad.Ref
+import Data.Dependent.Sum
+import Data.Functor.Identity
+
+import Reflex
+import Reflex.Host.Class
+
+runApp :: (Show a, t ~ SpiderTimeline Global, m ~ SpiderHost Global)
+       => (Event t () -> PerformEventT t m (Maybe (Ref m (Maybe (EventTrigger t ()))), Event t a))
+       -> IO (Maybe a, Maybe (a, a))
+runApp x = runSpiderHost $ do
+  (pulseE, pulseTriggerRef) <- newEventWithTriggerRef
+  ((mactuateRef, e), FireCommand fire) <- hostPerformEventT $ x pulseE
+  hnd <- subscribeEvent e
+  out1 <- fireEventRefAndRead pulseTriggerRef () hnd
+  out2 <- fmap join $ forM mactuateRef $ \actuateRef -> do
+    let readPhase = do
+          mGetValue <- readEvent hnd
+          case mGetValue of
+            Nothing -> return Nothing
+            Just getValue -> fmap Just getValue
+    mactuate <- readRef actuateRef
+    mpulse <- readRef pulseTriggerRef
+    forM ((,) <$> mactuate <*> mpulse) $ \(actuate, pulse) -> do
+      _ <- fire [actuate :=> Identity ()] $ return ()
+      [Just a] <- fire [pulse :=> Identity ()] $ readPhase
+      [Just b, Nothing] <- fire [actuate :=> Identity (), pulse :=> Identity ()] $ readPhase
+      return (a,b)
+  return (out1, out2)

--- a/test/hlint.hs
+++ b/test/hlint.hs
@@ -31,7 +31,7 @@ main = do
         , let notElem' = liftOp notElem
           in filePath `notElem'` filePathExceptions pwd
         ]
-  files <- find always matchFile pwd
+  files <- find recurseInto matchFile pwd
   ideas <- fmap concat $ forM files $ \f -> do
     putStr $ "linting file " ++ drop (length pwd + 1) f ++ "... "
     runHlint f

--- a/test/hlint.hs
+++ b/test/hlint.hs
@@ -1,19 +1,43 @@
+module Main where
+
+import Control.Monad
 import Language.Haskell.HLint3 (hlint)
+import System.Directory
 import System.Exit (exitFailure, exitSuccess)
+import System.FilePath.Find
+import System.FilePath
 
 main :: IO ()
 main = do
-  ideas <- hlint
-    [ "."
-    , "--ignore=Redundant do"
-    , "--ignore=Use camelCase"
-    , "--ignore=Redundant $"
-    , "--ignore=Use &&"
-    , "--ignore=Use &&&"
-    , "--ignore=Use const"
-    , "--ignore=Use >=>"
-    , "--ignore=Use ."
-    , "--ignore=Use unless"
-    , "--cpp-define=USE_TEMPLATE_HASKELL"
-    ]
+  pwd <- getCurrentDirectory
+  let runHlint f = hlint $ f:
+        [ "--ignore=Redundant do"
+        , "--ignore=Use camelCase"
+        , "--ignore=Redundant $"
+        , "--ignore=Use &&"
+        , "--ignore=Use &&&"
+        , "--ignore=Use const"
+        , "--ignore=Use >=>"
+        , "--ignore=Use ."
+        , "--ignore=Use unless"
+        , "--cpp-define=USE_TEMPLATE_HASKELL"
+        ]
+      recurseInto = and <$> sequence
+        [ fileType ==? Directory
+        , fileName /=? ".git"
+        ]
+      matchFile = and <$> sequence
+        [ extension ==? ".hs"
+        , let notElem' = liftOp notElem
+          in filePath `notElem'` filePathExceptions pwd
+        ]
+  files <- find always matchFile pwd
+  ideas <- fmap concat $ forM files $ \f -> do
+    putStr $ "linting file " ++ drop (length pwd + 1) f ++ "... "
+    runHlint f
   if null ideas then exitSuccess else exitFailure
+
+filePathExceptions :: FilePath -> [FilePath]
+filePathExceptions pwd = map (pwd </>) $
+  [ "src/Data/AppendMap.hs" -- parse error when hlint runs
+  ]


### PR DESCRIPTION
- QueryT had a bug with runWithReplace where changing query at the same time as changing a child widget brought the app to an inconsistent state.
- hlint tests were broken, possibly by type applications being unsupported by hs source extensions, so the hlist test was improved so that we can mark modules as exceptions
- the tests for QueryT were similar to, but a little more complicated than the tests for RequesterT and EventWriterT, so a common apparatus for running all the tests was developed which will improve code reuse for future semantic tests.