### PR TITLE
Specify 8.0.1 as minimal GHC release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - /nix
 matrix:
   include:
-  - env: COMPILER=ghc7103
   - env: COMPILER=ghc801
   - env: COMPILER=ghcjs
 script:

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -47,7 +47,7 @@ library
   hs-source-dirs: src
   build-depends:
     MemoTrie == 0.6.*,
-    base >= 4.7 && < 4.11,
+    base >= 4.9 && < 4.11,
     bifunctors >= 5.2 && < 5.5,
     containers == 0.5.*,
     data-default >= 0.5 && < 0.8,


### PR DESCRIPTION
It's no longer possible to compile reflex with GHC-7.0.3.  The current error is:

```
src/Data/AppendMap.hs:10:14:
    Unsupported extension: TypeApplications
```
This PR sets the necessary version of base to 4.9 so the minimal GHC version is now 8.0.1. 

After merge of this PR, issue #99 can be closed.