### PR TITLE
Eliminate the only use of TypeApplications

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -213,6 +213,8 @@ test-suite GC-Semantics
                , transformers
                , reflex
                , ref-tf
+  if impl(ghc < 8)
+    build-depends: semigroups
 
 test-suite rootCleanup
   type: exitcode-stdio-1.0

--- a/src/Data/AppendMap.hs
+++ b/src/Data/AppendMap.hs
@@ -324,13 +324,13 @@ isSubmapOf :: forall k a. (Ord k, Eq a) => AppendMap k a -> AppendMap k a -> Boo
 isSubmapOf = coerce (Map.isSubmapOf :: Map k a -> Map k a -> Bool)
 
 isSubmapOfBy :: forall k a b. Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
-isSubmapOfBy = coerce (Map.isSubmapOfBy:: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
+isSubmapOfBy = coerce (Map.isSubmapOfBy :: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
 
 isProperSubmapOf :: forall k a. (Ord k, Eq a) => AppendMap k a -> AppendMap k a -> Bool
 isProperSubmapOf = coerce (Map.isProperSubmapOf :: Map k a -> Map k a -> Bool)
 
 isProperSubmapOfBy :: forall k a b. Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
-isProperSubmapOfBy = coerce (Map.isProperSubmapOfBy:: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
+isProperSubmapOfBy = coerce (Map.isProperSubmapOfBy :: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
 
 lookupIndex :: forall k a. Ord k => k -> AppendMap k a -> Maybe Int
 lookupIndex = coerce (Map.lookupIndex :: k -> Map k a -> Maybe Int)
@@ -366,16 +366,16 @@ deleteFindMax :: forall k a. AppendMap k a -> ((k, a), AppendMap k a)
 deleteFindMax = coerce (Map.deleteFindMax :: Map k a -> ((k, a), Map k a))
 
 updateMin :: forall k a. (a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMin = coerce (Map.updateMin:: (a -> Maybe a) -> Map k a -> Map k a)
+updateMin = coerce (Map.updateMin :: (a -> Maybe a) -> Map k a -> Map k a)
 
 updateMax :: forall k a. (a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMax = coerce (Map.updateMax:: (a -> Maybe a) -> Map k a -> Map k a)
+updateMax = coerce (Map.updateMax :: (a -> Maybe a) -> Map k a -> Map k a)
 
 updateMinWithKey :: forall k a. (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMinWithKey = coerce (Map.updateMinWithKey:: (k -> a -> Maybe a) -> Map k a -> Map k a)
+updateMinWithKey = coerce (Map.updateMinWithKey :: (k -> a -> Maybe a) -> Map k a -> Map k a)
 
 updateMaxWithKey :: forall k a. (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMaxWithKey = coerce (Map.updateMaxWithKey:: (k -> a -> Maybe a) -> Map k a -> Map k a)
+updateMaxWithKey = coerce (Map.updateMaxWithKey :: (k -> a -> Maybe a) -> Map k a -> Map k a)
 
 minView :: forall k a. AppendMap k a -> Maybe (a, AppendMap k a)
 minView = coerce (Map.minView :: Map k a -> Maybe (a, Map k a))
@@ -393,7 +393,7 @@ showTree :: forall k a. (Show k, Show a) => AppendMap k a -> String
 showTree = coerce (Map.showTree :: (Show k, Show a) => Map k a -> String)
 
 showTreeWith :: forall k a. (k -> a -> String) -> Bool -> Bool -> AppendMap k a -> String
-showTreeWith = coerce (Map.showTreeWith:: (k -> a -> String) -> Bool -> Bool -> Map k a -> String)
+showTreeWith = coerce (Map.showTreeWith :: (k -> a -> String) -> Bool -> Bool -> Map k a -> String)
 
 valid :: forall k a. Ord k => AppendMap k a -> Bool
 valid = coerce (Map.valid :: Ord k => Map k a -> Bool)

--- a/src/Data/AppendMap.hs
+++ b/src/Data/AppendMap.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 -- | 'Data.Map' with a better 'Monoid' instance
 --
@@ -86,108 +85,108 @@ instance (Ord k, Group q) => Group (AppendMap k q) where
 instance (Ord k, Additive q) => Additive (AppendMap k q)
 
 (!) :: forall k a. Ord k => AppendMap k a -> k -> a
-(!) = coerce ((Map.!) @k @a)
+(!) = coerce ((Map.!) :: Map k a -> k -> a)
 infixl 9 !
 
 (\\) :: forall k a b. Ord k => AppendMap k a -> AppendMap k b -> AppendMap k a
-(\\) = coerce ((Map.\\) @k @a @b)
+(\\) = coerce ((Map.\\) :: Map k a -> Map k b -> Map k a)
 infixl 9 \\
 
 null :: forall k a. AppendMap k a -> Bool
-null = coerce (Map.null @k @a)
+null = coerce (Map.null :: Map k a -> Bool)
 
 size :: forall k a. AppendMap k a -> Int
-size = coerce (Map.size @k @a)
+size = coerce (Map.size :: Map k a -> Int)
 
 member :: forall k a. Ord k => k -> AppendMap k a -> Bool
-member = coerce (Map.member @k @a)
+member = coerce (Map.member :: k -> Map k a -> Bool)
 
 notMember :: forall k a. Ord k => k -> AppendMap k a -> Bool
-notMember = coerce (Map.notMember @k @a)
+notMember = coerce (Map.notMember :: k -> Map k a -> Bool)
 
 lookup :: forall k a. Ord k => k -> AppendMap k a -> Maybe a
-lookup = coerce (Map.lookup @k @a)
+lookup = coerce (Map.lookup :: k -> Map k a -> Maybe a)
 
 findWithDefault :: forall k a. Ord k => a -> k -> AppendMap k a -> a
-findWithDefault = coerce (Map.findWithDefault @k @a)
+findWithDefault = coerce (Map.findWithDefault :: a -> k -> Map k a -> a)
 
 lookupLT :: forall k a. Ord k => k -> AppendMap k a -> Maybe (k, a)
-lookupLT = coerce (Map.lookupLT @k @a)
+lookupLT = coerce (Map.lookupLT :: k -> Map k a -> Maybe (k,a))
 
 lookupGT :: forall k a. Ord k => k -> AppendMap k a -> Maybe (k, a)
-lookupGT = coerce (Map.lookupGT @k @a)
+lookupGT = coerce (Map.lookupGT :: k -> Map k a -> Maybe (k,a))
 
 lookupLE :: forall k a. Ord k => k -> AppendMap k a -> Maybe (k, a)
-lookupLE = coerce (Map.lookupLE @k @a)
+lookupLE = coerce (Map.lookupLE :: k -> Map k a -> Maybe (k,a))
 
 lookupGE :: forall k a. Ord k => k -> AppendMap k a -> Maybe (k, a)
-lookupGE = coerce (Map.lookupGE @k @a)
+lookupGE = coerce (Map.lookupGE :: k -> Map k a -> Maybe (k,a))
 
 empty :: forall k a. AppendMap k a
-empty = coerce (Map.empty @k @a)
+empty = coerce (Map.empty :: Map k a)
 
 singleton :: forall k a. k -> a -> AppendMap k a
-singleton = coerce (Map.singleton @k @a)
+singleton = coerce (Map.singleton :: k -> a -> Map k a)
 
 insert :: forall k a. Ord k => k -> a -> AppendMap k a -> AppendMap k a
-insert = coerce (Map.insert @k @a)
+insert = coerce (Map.insert :: k -> a -> Map k a -> Map k a)
 
-insertWith :: Ord k => (a -> a -> a) -> k -> a -> AppendMap k a -> AppendMap k a
-insertWith f = coerce (Map.insertWith f)
+insertWith :: forall k a. Ord k => (a -> a -> a) -> k -> a -> AppendMap k a -> AppendMap k a
+insertWith = coerce (Map.insertWith :: (a -> a -> a) -> k -> a -> Map k a -> Map k a)
 
-insertWithKey :: Ord k => (k -> a -> a -> a) -> k -> a -> AppendMap k a -> AppendMap k a
-insertWithKey f = coerce (Map.insertWithKey f)
+insertWithKey :: forall k a. Ord k => (k -> a -> a -> a) -> k -> a -> AppendMap k a -> AppendMap k a
+insertWithKey = coerce (Map.insertWithKey :: (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a)
 
-insertLookupWithKey :: Ord k => (k -> a -> a -> a) -> k -> a -> AppendMap k a -> (Maybe a, AppendMap k a)
-insertLookupWithKey f = coerce (Map.insertLookupWithKey f)
+insertLookupWithKey :: forall k a. Ord k => (k -> a -> a -> a) -> k -> a -> AppendMap k a -> (Maybe a, AppendMap k a)
+insertLookupWithKey = coerce (Map.insertLookupWithKey :: (k -> a -> a -> a) -> k -> a -> Map k a -> (Maybe a, Map k a))
 
 delete :: forall k a. Ord k => k -> AppendMap k a -> AppendMap k a
-delete = coerce (Map.delete @k @a)
+delete = coerce (Map.delete :: k -> Map k a -> Map k a)
 
-adjust :: Ord k => (a -> a) -> k -> AppendMap k a -> AppendMap k a
-adjust f = coerce (Map.adjust f)
+adjust :: forall k a. Ord k => (a -> a) -> k -> AppendMap k a -> AppendMap k a
+adjust = coerce (Map.adjust :: (a -> a) -> k -> Map k a -> Map k a)
 
-adjustWithKey :: Ord k => (k -> a -> a) -> k -> AppendMap k a -> AppendMap k a
-adjustWithKey f = coerce (Map.adjustWithKey f)
+adjustWithKey :: forall k a. Ord k => (k -> a -> a) -> k -> AppendMap k a -> AppendMap k a
+adjustWithKey = coerce (Map.adjustWithKey :: (k -> a -> a) -> k -> Map k a -> Map k a)
 
-update :: Ord k => (a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
-update f = coerce (Map.update f)
+update :: forall k a. Ord k => (a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
+update = coerce (Map.update :: (a -> Maybe a) -> k -> Map k a -> Map k a)
 
-updateWithKey :: Ord k => (k -> a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
-updateWithKey f = coerce (Map.updateWithKey f)
+updateWithKey :: forall k a. Ord k => (k -> a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
+updateWithKey = coerce (Map.updateWithKey :: (k -> a -> Maybe a) -> k -> Map k a -> Map k a)
 
-updateLookupWithKey :: Ord k => (k -> a -> Maybe a) -> k -> AppendMap k a -> (Maybe a, AppendMap k a)
-updateLookupWithKey f = coerce (Map.updateLookupWithKey f)
+updateLookupWithKey :: forall k a. Ord k => (k -> a -> Maybe a) -> k -> AppendMap k a -> (Maybe a, AppendMap k a)
+updateLookupWithKey = coerce (Map.updateLookupWithKey :: (k -> a -> Maybe a) -> k -> Map k a -> (Maybe a, Map k a))
 
-alter :: Ord k => (Maybe a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
-alter f = coerce (Map.alter f)
+alter :: forall k a. Ord k => (Maybe a -> Maybe a) -> k -> AppendMap k a -> AppendMap k a
+alter = coerce (Map.alter :: (Maybe a -> Maybe a) -> k -> Map k a -> Map k a)
 
-unionWith :: Ord k => (a -> a -> a) -> AppendMap k a -> AppendMap k a -> AppendMap k a
-unionWith f = coerce (Map.unionWith f)
+unionWith :: forall k a. Ord k => (a -> a -> a) -> AppendMap k a -> AppendMap k a -> AppendMap k a
+unionWith = coerce (Map.unionWith :: (a -> a -> a) -> Map k a -> Map k a -> Map k a)
 
-unionWithKey :: Ord k => (k -> a -> a -> a) -> AppendMap k a -> AppendMap k a -> AppendMap k a
-unionWithKey f = coerce (Map.unionWithKey f)
+unionWithKey :: forall k a. Ord k => (k -> a -> a -> a) -> AppendMap k a -> AppendMap k a -> AppendMap k a
+unionWithKey = coerce (Map.unionWithKey :: (k -> a -> a -> a) -> Map k a -> Map k a -> Map k a)
 
-unionsWith :: Ord k => (a -> a -> a) -> [AppendMap k a] -> AppendMap k a
-unionsWith f = coerce (Map.unionsWith f)
+unionsWith :: forall k a. Ord k => (a -> a -> a) -> [AppendMap k a] -> AppendMap k a
+unionsWith = coerce (Map.unionsWith :: (a -> a -> a) -> [Map k a] -> Map k a)
 
-difference :: Ord k => AppendMap k a -> AppendMap k b -> AppendMap k a
+difference :: forall k a b. Ord k => AppendMap k a -> AppendMap k b -> AppendMap k a
 difference = (\\)
 
-differenceWith :: Ord k => (a -> b -> Maybe a) -> AppendMap k a -> AppendMap k b -> AppendMap k a
-differenceWith f = coerce (Map.differenceWith f)
+differenceWith :: forall k a b. Ord k => (a -> b -> Maybe a) -> AppendMap k a -> AppendMap k b -> AppendMap k a
+differenceWith = coerce (Map.differenceWith :: (a -> b -> Maybe a) -> Map k a -> Map k b -> Map k a)
 
-differenceWithKey :: Ord k => (k -> a -> b -> Maybe a) -> AppendMap k a -> AppendMap k b -> AppendMap k a
-differenceWithKey f = coerce (Map.differenceWithKey f)
+differenceWithKey :: forall k a b. Ord k => (k -> a -> b -> Maybe a) -> AppendMap k a -> AppendMap k b -> AppendMap k a
+differenceWithKey = coerce (Map.differenceWithKey :: (k -> a -> b -> Maybe a) -> Map k a -> Map k b -> Map k a)
 
-intersectionWith :: Ord k => (a -> b -> c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
-intersectionWith f = coerce (Map.intersectionWith f)
+intersectionWith :: forall k a b c. Ord k => (a -> b -> c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
+intersectionWith = coerce (Map.intersectionWith :: (a -> b -> c) -> Map k a -> Map k b -> Map k c)
 
-intersectionWithKey :: Ord k => (k -> a -> b -> c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
-intersectionWithKey f = coerce (Map.intersectionWithKey f)
+intersectionWithKey :: forall k a b c. Ord k => (k -> a -> b -> c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
+intersectionWithKey = coerce (Map.intersectionWithKey :: (k -> a -> b -> c) -> Map k a -> Map k b -> Map k c)
 
-mergeWithKey :: Ord k => (k -> a -> b -> Maybe c) -> (AppendMap k a -> AppendMap k c) -> (AppendMap k b -> AppendMap k c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
-mergeWithKey f = coerce (Map.mergeWithKey f)
+mergeWithKey :: forall k a b c. Ord k => (k -> a -> b -> Maybe c) -> (AppendMap k a -> AppendMap k c) -> (AppendMap k b -> AppendMap k c) -> AppendMap k a -> AppendMap k b -> AppendMap k c
+mergeWithKey = coerce (Map.mergeWithKey :: (k -> a -> b -> Maybe c) -> (Map k a -> Map k c) -> (Map k b -> Map k c) -> Map k a -> Map k b -> Map k c)
 
 map :: (a -> b) -> AppendMap k a -> AppendMap k b
 map = fmap
@@ -198,206 +197,206 @@ mapWithKey = imap
 traverseWithKey :: Applicative t => (k -> a -> t b) -> AppendMap k a -> t (AppendMap k b)
 traverseWithKey = itraverse
 
-mapAccum :: (a -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
-mapAccum f = coerce (Map.mapAccum f)
+mapAccum :: forall k a b c. (a -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
+mapAccum = coerce (Map.mapAccum :: (a -> b -> (a, c)) -> a -> Map k b -> (a, Map k c))
 
-mapAccumWithKey :: (a -> k -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
-mapAccumWithKey f = coerce (Map.mapAccumWithKey f)
+mapAccumWithKey :: forall k a b c. (a -> k -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
+mapAccumWithKey = coerce (Map.mapAccumWithKey :: (a -> k -> b -> (a, c)) -> a -> Map k b -> (a, Map k c))
 
-mapAccumRWithKey :: (a -> k -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
-mapAccumRWithKey f = coerce (Map.mapAccumRWithKey f)
+mapAccumRWithKey :: forall k a b c. (a -> k -> b -> (a, c)) -> a -> AppendMap k b -> (a, AppendMap k c)
+mapAccumRWithKey = coerce (Map.mapAccumRWithKey :: (a -> k -> b -> (a, c)) -> a -> Map k b -> (a, Map k c))
 
 mapKeys :: forall k1 k2 a. Ord k2 => (k1 -> k2) -> AppendMap k1 a -> AppendMap k2 a
-mapKeys = coerce (Map.mapKeys @k2 @k1 @a)
+mapKeys = coerce (Map.mapKeys :: (k1 -> k2) -> Map k1 a -> Map k2 a)
 
-mapKeysWith :: Ord k2 => (a -> a -> a) -> (k1 -> k2) -> AppendMap k1 a -> AppendMap k2 a
-mapKeysWith f = coerce (Map.mapKeysWith f)
+mapKeysWith :: forall k1 k2 a. Ord k2 => (a -> a -> a) -> (k1 -> k2) -> AppendMap k1 a -> AppendMap k2 a
+mapKeysWith = coerce (Map.mapKeysWith :: (a -> a -> a) -> (k1 -> k2) -> Map k1 a -> Map k2 a)
 
 mapKeysMonotonic :: forall k1 k2 a. (k1 -> k2) -> AppendMap k1 a -> AppendMap k2 a
-mapKeysMonotonic = coerce (Map.mapKeysMonotonic @k1 @k2 @a)
+mapKeysMonotonic = coerce (Map.mapKeysMonotonic :: (k1 -> k2) -> Map k1 a -> Map k2 a)
 
-foldr :: (a -> b -> b) -> b -> AppendMap k a -> b
-foldr f = coerce (Map.foldr f)
+foldr :: forall k a b. (a -> b -> b) -> b -> AppendMap k a -> b
+foldr = coerce (Map.foldr :: (a -> b -> b) -> b -> Map k a -> b)
 
-foldl :: (a -> b -> a) -> a -> AppendMap k b -> a
-foldl f = coerce (Map.foldl f)
+foldl :: forall k a b. (a -> b -> a) -> a -> AppendMap k b -> a
+foldl = coerce (Map.foldl :: (a -> b -> a) -> a -> Map k b -> a)
 
-foldrWithKey :: (k -> a -> b -> b) -> b -> AppendMap k a -> b
-foldrWithKey f = coerce (Map.foldrWithKey f)
+foldrWithKey :: forall k a b. (k -> a -> b -> b) -> b -> AppendMap k a -> b
+foldrWithKey = coerce (Map.foldrWithKey :: (k -> a -> b -> b) -> b -> Map k a -> b)
 
-foldlWithKey :: (a -> k -> b -> a) -> a -> AppendMap k b -> a
-foldlWithKey f = coerce (Map.foldlWithKey f)
+foldlWithKey :: forall k a b. (a -> k -> b -> a) -> a -> AppendMap k b -> a
+foldlWithKey = coerce (Map.foldlWithKey :: (a -> k -> b -> a) -> a -> Map k b -> a)
 
-foldMapWithKey :: Monoid m => (k -> a -> m) -> AppendMap k a -> m
-foldMapWithKey f = coerce (Map.foldMapWithKey f)
+foldMapWithKey :: forall k a m. Monoid m => (k -> a -> m) -> AppendMap k a -> m
+foldMapWithKey = coerce (Map.foldMapWithKey :: Monoid m => (k -> a -> m) -> Map k a -> m)
 
-foldr' :: (a -> b -> b) -> b -> AppendMap k a -> b
-foldr' f = coerce (Map.foldr' f)
+foldr' :: forall k a b. (a -> b -> b) -> b -> AppendMap k a -> b
+foldr' = coerce (Map.foldr' :: (a -> b -> b) -> b -> Map k a -> b)
 
-foldl' :: (a -> b -> a) -> a -> AppendMap k b -> a
-foldl' f = coerce (Map.foldl' f)
+foldl' :: forall k a b. (a -> b -> a) -> a -> AppendMap k b -> a
+foldl' = coerce (Map.foldl' :: (a -> b -> a) -> a -> Map k b -> a)
 
-foldrWithKey' :: (k -> a -> b -> b) -> b -> AppendMap k a -> b
-foldrWithKey' f = coerce (Map.foldrWithKey' f)
+foldrWithKey' :: forall k a b. (k -> a -> b -> b) -> b -> AppendMap k a -> b
+foldrWithKey' = coerce (Map.foldrWithKey' :: (k -> a -> b -> b) -> b -> Map k a -> b)
 
-foldlWithKey' :: (a -> k -> b -> a) -> a -> AppendMap k b -> a
-foldlWithKey' f = coerce (Map.foldlWithKey' f)
+foldlWithKey' :: forall k a b. (a -> k -> b -> a) -> a -> AppendMap k b -> a
+foldlWithKey' = coerce (Map.foldlWithKey' :: (a -> k -> b -> a) -> a -> Map k b -> a)
 
 elems :: forall k a. AppendMap k a -> [a]
-elems = coerce (Map.elems @k @a)
+elems = coerce (Map.elems :: Map k a -> [a])
 
 keys :: forall k a. AppendMap k a -> [k]
-keys = coerce (Map.keys @k @a)
+keys = coerce (Map.keys :: Map k a -> [k])
 
 assocs :: forall k a. AppendMap k a -> [(k, a)]
-assocs = coerce (Map.assocs @k @a)
+assocs = coerce (Map.assocs :: Map k a -> [(k, a)])
 
 keysSet :: forall k a. AppendMap k a -> Set k
-keysSet = coerce (Map.keysSet @k @a)
+keysSet = coerce (Map.keysSet :: Map k a -> Set k)
 
-fromSet :: (k -> a) -> Set k -> AppendMap k a
-fromSet f = coerce (Map.fromSet f)
+fromSet :: forall k a. (k -> a) -> Set k -> AppendMap k a
+fromSet = coerce (Map.fromSet :: (k -> a) -> Set k -> Map k a)
 
 toList :: forall k a. AppendMap k a -> [(k, a)]
-toList = coerce (Map.toList @k @a)
+toList = coerce (Map.toList :: Map k a -> [(k, a)])
 
 fromList :: forall k a. Ord k => [(k, a)] -> AppendMap k a
-fromList = coerce (Map.fromList @k @a)
+fromList = coerce (Map.fromList :: [(k, a)] -> Map k a)
 
-fromListWith :: Ord k => (a -> a -> a) -> [(k, a)] -> AppendMap k a
-fromListWith f = coerce (Map.fromListWith f)
+fromListWith :: forall k a. Ord k => (a -> a -> a) -> [(k, a)] -> AppendMap k a
+fromListWith = coerce (Map.fromListWith :: (a -> a -> a) -> [(k, a)] -> Map k a)
 
-fromListWithKey :: Ord k => (k -> a -> a -> a) -> [(k, a)] -> AppendMap k a
-fromListWithKey f = coerce (Map.fromListWithKey f)
+fromListWithKey :: forall k a. Ord k => (k -> a -> a -> a) -> [(k, a)] -> AppendMap k a
+fromListWithKey = coerce (Map.fromListWithKey :: (k -> a -> a -> a) -> [(k, a)] -> Map k a)
 
 toAscList :: forall k a. AppendMap k a -> [(k, a)]
-toAscList = coerce (Map.toAscList @k @a)
+toAscList = coerce (Map.toAscList :: Map k a -> [(k, a)])
 
 toDescList :: forall k a. AppendMap k a -> [(k, a)]
-toDescList = coerce (Map.toDescList @k @a)
+toDescList = coerce (Map.toDescList :: Map k a -> [(k, a)])
 
 fromAscList :: forall k a. Eq k => [(k, a)] -> AppendMap k a
-fromAscList = coerce (Map.fromAscList @k @a)
+fromAscList = coerce (Map.fromAscList :: [(k, a)] -> Map k a)
 
-fromAscListWith :: Eq k => (a -> a -> a) -> [(k, a)] -> AppendMap k a
-fromAscListWith f = coerce (Map.fromAscListWith f)
+fromAscListWith :: forall k a. Eq k => (a -> a -> a) -> [(k, a)] -> AppendMap k a
+fromAscListWith = coerce (Map.fromAscListWith :: (a -> a -> a) -> [(k, a)] -> Map k a)
 
-fromAscListWithKey :: Eq k => (k -> a -> a -> a) -> [(k, a)] -> AppendMap k a
-fromAscListWithKey f = coerce (Map.fromAscListWithKey f)
+fromAscListWithKey :: forall k a. Eq k => (k -> a -> a -> a) -> [(k, a)] -> AppendMap k a
+fromAscListWithKey = coerce (Map.fromAscListWithKey :: (k -> a -> a -> a) -> [(k, a)] -> Map k a)
 
 fromDistinctAscList :: forall k a. [(k, a)] -> AppendMap k a
-fromDistinctAscList = coerce (Map.fromDistinctAscList @k @a)
+fromDistinctAscList = coerce (Map.fromDistinctAscList :: [(k, a)] -> Map k a)
 
-filter :: (a -> Bool) -> AppendMap k a -> AppendMap k a
-filter f = coerce (Map.filter f)
+filter :: forall k a. (a -> Bool) -> AppendMap k a -> AppendMap k a
+filter = coerce (Map.filter :: (a -> Bool) -> Map k a -> Map k a)
 
-filterWithKey :: (k -> a -> Bool) -> AppendMap k a -> AppendMap k a
-filterWithKey f = coerce (Map.filterWithKey f)
+filterWithKey :: forall k a. (k -> a -> Bool) -> AppendMap k a -> AppendMap k a
+filterWithKey = coerce (Map.filterWithKey :: (k -> a -> Bool) -> Map k a -> Map k a)
 
-partition :: (a -> Bool) -> AppendMap k a -> (AppendMap k a, AppendMap k a)
-partition f = coerce (Map.partition f)
+partition :: forall k a. (a -> Bool) -> AppendMap k a -> (AppendMap k a, AppendMap k a)
+partition = coerce (Map.partition :: (a -> Bool) -> Map k a -> (Map k a, Map k a))
 
-partitionWithKey :: (k -> a -> Bool) -> AppendMap k a -> (AppendMap k a, AppendMap k a)
-partitionWithKey f = coerce (Map.partitionWithKey f)
+partitionWithKey :: forall k a. (k -> a -> Bool) -> AppendMap k a -> (AppendMap k a, AppendMap k a)
+partitionWithKey = coerce (Map.partitionWithKey :: (k -> a -> Bool) -> Map k a -> (Map k a, Map k a))
 
-mapMaybe :: (a -> Maybe b) -> AppendMap k a -> AppendMap k b
-mapMaybe f = coerce (Map.mapMaybe f)
+mapMaybe :: forall k a b. (a -> Maybe b) -> AppendMap k a -> AppendMap k b
+mapMaybe = coerce (Map.mapMaybe :: (a -> Maybe b) -> Map k a -> Map k b)
 
-mapMaybeWithKey :: (k -> a -> Maybe b) -> AppendMap k a -> AppendMap k b
-mapMaybeWithKey f = coerce (Map.mapMaybeWithKey f)
+mapMaybeWithKey :: forall k a b. (k -> a -> Maybe b) -> AppendMap k a -> AppendMap k b
+mapMaybeWithKey = coerce (Map.mapMaybeWithKey :: (k -> a -> Maybe b) -> Map k a -> Map k b)
 
-mapEither :: (a -> Either b c) -> AppendMap k a -> (AppendMap k b, AppendMap k c)
-mapEither f = coerce (Map.mapEither f)
+mapEither :: forall k a b c. (a -> Either b c) -> AppendMap k a -> (AppendMap k b, AppendMap k c)
+mapEither = coerce (Map.mapEither :: (a -> Either b c) -> Map k a -> (Map k b, Map k c))
 
-mapEitherWithKey :: (k -> a -> Either b c) -> AppendMap k a -> (AppendMap k b, AppendMap k c)
-mapEitherWithKey f = coerce (Map.mapEitherWithKey f)
+mapEitherWithKey :: forall k a b c. (k -> a -> Either b c) -> AppendMap k a -> (AppendMap k b, AppendMap k c)
+mapEitherWithKey = coerce (Map.mapEitherWithKey :: (k -> a -> Either b c) -> Map k a -> (Map k b, Map k c))
 
 split :: forall k a. Ord k => k -> AppendMap k a -> (AppendMap k a, AppendMap k a)
-split = coerce (Map.split @k @a)
+split = coerce (Map.split :: k -> Map k a -> (Map k a, Map k a))
 
 splitLookup :: forall k a. Ord k => k -> AppendMap k a -> (AppendMap k a, Maybe a, AppendMap k a)
-splitLookup = coerce (Map.splitLookup @k @a)
+splitLookup = coerce (Map.splitLookup :: k -> Map k a -> (Map k a, Maybe a, Map k a))
 
 splitRoot :: forall k a. AppendMap k a -> [AppendMap k a]
-splitRoot = coerce (Map.splitRoot @k @a)
+splitRoot = coerce (Map.splitRoot :: Map k a -> [Map k a])
 
 isSubmapOf :: forall k a. (Ord k, Eq a) => AppendMap k a -> AppendMap k a -> Bool
-isSubmapOf = coerce (Map.isSubmapOf @k @a)
+isSubmapOf = coerce (Map.isSubmapOf :: Map k a -> Map k a -> Bool)
 
-isSubmapOfBy :: Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
-isSubmapOfBy f = coerce (Map.isSubmapOfBy f)
+isSubmapOfBy :: forall k a b. Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
+isSubmapOfBy = coerce (Map.isSubmapOfBy:: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
 
 isProperSubmapOf :: forall k a. (Ord k, Eq a) => AppendMap k a -> AppendMap k a -> Bool
-isProperSubmapOf = coerce (Map.isProperSubmapOf @k @a)
+isProperSubmapOf = coerce (Map.isProperSubmapOf :: Map k a -> Map k a -> Bool)
 
-isProperSubmapOfBy :: Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
-isProperSubmapOfBy f = coerce (Map.isProperSubmapOfBy f)
+isProperSubmapOfBy :: forall k a b. Ord k => (a -> b -> Bool) -> AppendMap k a -> AppendMap k b -> Bool
+isProperSubmapOfBy = coerce (Map.isProperSubmapOfBy:: (a -> b -> Bool) -> Map k a -> Map k b -> Bool)
 
 lookupIndex :: forall k a. Ord k => k -> AppendMap k a -> Maybe Int
-lookupIndex = coerce (Map.lookupIndex @k @a)
+lookupIndex = coerce (Map.lookupIndex :: k -> Map k a -> Maybe Int)
 
 findIndex :: forall k a. Ord k => k -> AppendMap k a -> Int
-findIndex = coerce (Map.findIndex @k @a)
+findIndex = coerce (Map.findIndex :: k -> Map k a -> Int)
 
 elemAt :: forall k a. Int -> AppendMap k a -> (k, a)
-elemAt = coerce (Map.elemAt @k @a)
+elemAt = coerce (Map.elemAt :: Int -> Map k a -> (k, a))
 
 updateAt :: forall k a. (k -> a -> Maybe a) -> Int -> AppendMap k a -> AppendMap k a
-updateAt = coerce (Map.updateAt @k @a)
+updateAt = coerce (Map.updateAt :: (k -> a -> Maybe a) -> Int -> Map k a -> Map k a)
 
 deleteAt :: forall k a. Int -> AppendMap k a -> AppendMap k a
-deleteAt = coerce (Map.deleteAt @k @a)
+deleteAt = coerce (Map.deleteAt :: Int -> Map k a -> Map k a)
 
 findMin :: forall k a. AppendMap k a -> (k, a)
-findMin = coerce (Map.findMin @k @a)
+findMin = coerce (Map.findMin :: Map k a -> (k, a))
 
 findMax :: forall k a. AppendMap k a -> (k, a)
-findMax = coerce (Map.findMax @k @a)
+findMax = coerce (Map.findMax :: Map k a -> (k, a))
 
 deleteMin :: forall k a. AppendMap k a -> AppendMap k a
-deleteMin = coerce (Map.deleteMin @k @ a)
+deleteMin = coerce (Map.deleteMin :: Map k a -> Map k a)
 
 deleteMax :: forall k a. AppendMap k a -> AppendMap k a
-deleteMax = coerce (Map.deleteMax @k @a)
+deleteMax = coerce (Map.deleteMax :: Map k a -> Map k a)
 
 deleteFindMin :: forall k a. AppendMap k a -> ((k, a), AppendMap k a)
-deleteFindMin = coerce (Map.deleteFindMin @k @a)
+deleteFindMin = coerce (Map.deleteFindMin :: Map k a -> ((k, a), Map k a))
 
 deleteFindMax :: forall k a. AppendMap k a -> ((k, a), AppendMap k a)
-deleteFindMax = coerce (Map.deleteFindMax @k @a)
+deleteFindMax = coerce (Map.deleteFindMax :: Map k a -> ((k, a), Map k a))
 
-updateMin :: (a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMin f = coerce (Map.updateMin f)
+updateMin :: forall k a. (a -> Maybe a) -> AppendMap k a -> AppendMap k a
+updateMin = coerce (Map.updateMin:: (a -> Maybe a) -> Map k a -> Map k a)
 
-updateMax :: (a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMax f = coerce (Map.updateMax f)
+updateMax :: forall k a. (a -> Maybe a) -> AppendMap k a -> AppendMap k a
+updateMax = coerce (Map.updateMax:: (a -> Maybe a) -> Map k a -> Map k a)
 
-updateMinWithKey :: (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMinWithKey f = coerce (Map.updateMinWithKey f)
+updateMinWithKey :: forall k a. (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
+updateMinWithKey = coerce (Map.updateMinWithKey:: (k -> a -> Maybe a) -> Map k a -> Map k a)
 
-updateMaxWithKey :: (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
-updateMaxWithKey f = coerce (Map.updateMaxWithKey f)
+updateMaxWithKey :: forall k a. (k -> a -> Maybe a) -> AppendMap k a -> AppendMap k a
+updateMaxWithKey = coerce (Map.updateMaxWithKey:: (k -> a -> Maybe a) -> Map k a -> Map k a)
 
 minView :: forall k a. AppendMap k a -> Maybe (a, AppendMap k a)
-minView = coerce (Map.minView @k @a)
+minView = coerce (Map.minView :: Map k a -> Maybe (a, Map k a))
 
 maxView :: forall k a. AppendMap k a -> Maybe (a, AppendMap k a)
-maxView = coerce (Map.maxView @k @a)
+maxView = coerce (Map.maxView :: Map k a -> Maybe (a, Map k a))
 
 minViewWithKey :: forall k a. AppendMap k a -> Maybe ((k, a), AppendMap k a)
-minViewWithKey = coerce (Map.minViewWithKey @k @a)
+minViewWithKey = coerce (Map.minViewWithKey :: Map k a -> Maybe ((k, a), Map k a))
 
 maxViewWithKey :: forall k a. AppendMap k a -> Maybe ((k, a), AppendMap k a)
-maxViewWithKey = coerce (Map.maxViewWithKey @k @a)
+maxViewWithKey = coerce (Map.maxViewWithKey :: Map k a -> Maybe ((k, a), Map k a))
 
 showTree :: forall k a. (Show k, Show a) => AppendMap k a -> String
-showTree = coerce (Map.showTree @k @a)
+showTree = coerce (Map.showTree :: (Show k, Show a) => Map k a -> String)
 
-showTreeWith :: (k -> a -> String) -> Bool -> Bool -> AppendMap k a -> String
-showTreeWith f = coerce (Map.showTreeWith f)
+showTreeWith :: forall k a. (k -> a -> String) -> Bool -> Bool -> AppendMap k a -> String
+showTreeWith = coerce (Map.showTreeWith:: (k -> a -> String) -> Bool -> Bool -> Map k a -> String)
 
 valid :: forall k a. Ord k => AppendMap k a -> Bool
-valid = coerce (Map.valid @k @a)
+valid = coerce (Map.valid :: Ord k => Map k a -> Bool)
 
 instance Default (AppendMap k a) where
   def = empty

--- a/src/Data/Functor/Misc.hs
+++ b/src/Data/Functor/Misc.hs
@@ -291,7 +291,12 @@ dsumToEither = \case
 -- | We can't use @Compose Maybe@ instead of 'ComposeMaybe', because that would
 -- make the 'f' parameter have a nominal type role.  We need f to be
 -- representational so that we can use safe 'coerce'.
-newtype ComposeMaybe f a = ComposeMaybe { getComposeMaybe :: Maybe (f a) } deriving (Show, Eq, Ord)
+#if MIN_VERSION_transformers(5,2,0)
+newtype ComposeMaybe f a =
+#else
+newtype ComposeMaybe (f :: * -> *) (a :: *) =
+#endif
+   ComposeMaybe { getComposeMaybe :: Maybe (f a) } deriving (Show, Eq, Ord)
 
 deriving instance Functor f => Functor (ComposeMaybe f)
 

--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -38,6 +38,7 @@ module Reflex.Dynamic
   , scanDynMaybe
   , holdUniqDyn
   , holdUniqDynBy
+  , improvingMaybe
   , foldDyn
   , foldDynM
   , foldDynMaybe
@@ -115,6 +116,10 @@ holdUniqDyn = holdUniqDynBy (==)
 -- the new values.
 holdUniqDynBy :: (Reflex t, MonadHold t m, MonadFix m) => (a -> a -> Bool) -> Dynamic t a -> m (Dynamic t a)
 holdUniqDynBy eq = scanDynMaybe id (\new old -> if new `eq` old then Nothing else Just new)
+
+-- | Dynamic Maybe that can only update from Nothing to Just or Just to Just (i.e., cannot revert to Nothing)
+improvingMaybe :: (Reflex t, MonadHold t m, MonadFix m) => Dynamic t (Maybe a) -> m (Dynamic t (Maybe a))
+improvingMaybe = scanDynMaybe id (\new _ -> if isJust new then Just new else Nothing)
 
 -- | Create a 'Dynamic' that accumulates values from another 'Dynamic'.  This
 -- function does not force its input 'Dynamic' until the output 'Dynamic' is

--- a/src/Reflex/EventWriter.hs
+++ b/src/Reflex/EventWriter.hs
@@ -77,7 +77,7 @@ instance MonadHold t m => MonadHold t (EventWriterT t w m) where
   holdDyn v0 = lift . holdDyn v0
   holdIncremental v0 = lift . holdIncremental v0
 
-instance (Reflex t, MonadAdjust t m, MonadHold t m, Semigroup w, Semigroup w) => MonadAdjust t (EventWriterT t w m) where
+instance (Reflex t, MonadAdjust t m, MonadHold t m, Semigroup w) => MonadAdjust t (EventWriterT t w m) where
   runWithReplace = runWithReplaceEventWriterTWith $ \dm0 dm' -> lift $ runWithReplace dm0 dm'
   traverseDMapWithKeyWithAdjust = sequenceDMapWithAdjustEventWriterTWith (\f dm0 dm' -> lift $ traverseDMapWithKeyWithAdjust f dm0 dm') mapPatchDMap weakenPatchDMapWith patchMapNewElements mergeMapIncremental
   traverseDMapWithKeyWithAdjustWithMove = sequenceDMapWithAdjustEventWriterTWith (\f dm0 dm' -> lift $ traverseDMapWithKeyWithAdjustWithMove f dm0 dm') mapPatchDMapWithMove weakenPatchDMapWithMoveWith patchMapWithMoveNewElements mergeMapIncrementalWithMove
@@ -108,7 +108,7 @@ runWithReplaceEventWriterTWith f a0 a' = do
   return (fst result0, fmapCheap fst result')
 
 -- | Like 'runWithReplaceEventWriterTWith', but for 'sequenceDMapWithAdjust'.
-sequenceDMapWithAdjustEventWriterTWith :: forall t m p p' w k v v'. (Reflex t, MonadHold t m, Semigroup w, Semigroup w, Patch (p' (Some k) (Event t w)), PatchTarget (p' (Some k) (Event t w)) ~ Map (Some k) (Event t w))
+sequenceDMapWithAdjustEventWriterTWith :: forall t m p p' w k v v'. (Reflex t, MonadHold t m, Semigroup w, Patch (p' (Some k) (Event t w)), PatchTarget (p' (Some k) (Event t w)) ~ Map (Some k) (Event t w))
                                        => (   (forall a. k a -> v a -> m (Compose ((,) (Seq (Event t w))) v' a))
                                            -> DMap k v
                                            -> Event t (p k v)


### PR DESCRIPTION
We should be able to retain support for older GHCs a bit longer this way. (But see issue 99 for another problem facing 7.10.x.)