### PR TITLE
Renames MonadAdjust and moves it to its own module.

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -79,12 +79,14 @@ library
 
   exposed-modules:
     Data.AppendMap,
+    Data.Map.Misc,
     Data.Functor.Misc,
     Data.WeakBag,
     Data.FastWeakBag,
     Data.FastMutableIntMap,
     Reflex,
     Reflex.Class,
+    Reflex.Collection,
     Reflex.EventWriter,
     Reflex.Dynamic,
     Reflex.Dynamic.Uniq,

--- a/src/Data/Map/Misc.hs
+++ b/src/Data/Map/Misc.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE LambdaCase #-}
+module Data.Map.Misc 
+  (
+  -- * Working with Maps
+    diffMapNoEq
+  , diffMap
+  , applyMap
+  , mapPartitionEithers
+  , applyMapKeysSet
+  ) where
+
+import Data.Align
+import Data.Either
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.These
+
+diffMapNoEq :: (Ord k) => Map k v -> Map k v -> Map k (Maybe v)
+diffMapNoEq olds news = flip Map.mapMaybe (align olds news) $ \case
+  This _ -> Just Nothing
+  These _ new -> Just $ Just new
+  That new -> Just $ Just new
+
+diffMap :: (Ord k, Eq v) => Map k v -> Map k v -> Map k (Maybe v)
+diffMap olds news = flip Map.mapMaybe (align olds news) $ \case
+  This _ -> Just Nothing
+  These old new
+    | old == new -> Nothing
+    | otherwise -> Just $ Just new
+  That new -> Just $ Just new
+
+applyMap :: Ord k => Map k (Maybe v) -> Map k v -> Map k v
+applyMap patch old = insertions `Map.union` (old `Map.difference` deletions)
+  where (deletions, insertions) = mapPartitionEithers $ maybeToEither <$> patch
+        maybeToEither = \case
+          Nothing -> Left ()
+          Just r -> Right r
+
+mapPartitionEithers :: Map k (Either a b) -> (Map k a, Map k b)
+mapPartitionEithers m = (fromLeft <$> ls, fromRight <$> rs)
+  where (ls, rs) = Map.partition isLeft m
+        fromLeft (Left l) = l
+        fromLeft _ = error "mapPartitionEithers: fromLeft received a Right value; this should be impossible"
+        fromRight (Right r) = r
+        fromRight _ = error "mapPartitionEithers: fromRight received a Left value; this should be impossible"
+
+-- | Apply a map patch to a set
+-- > applyMapKeysSet patch (Map.keysSet m) == Map.keysSet (applyMap patch m)
+applyMapKeysSet :: Ord k => Map k (Maybe v) -> Set k -> Set k
+applyMapKeysSet patch old = Map.keysSet insertions `Set.union` (old `Set.difference` Map.keysSet deletions)
+  where (insertions, deletions) = Map.partition isJust patch
+

--- a/src/Reflex.hs
+++ b/src/Reflex.hs
@@ -6,6 +6,7 @@ module Reflex
   ) where
 
 import Reflex.Class as X
+import Reflex.Collection as X
 import Reflex.EventWriter as X
 import Reflex.Dynamic as X
 #ifdef USE_TEMPLATE_HASKELL

--- a/src/Reflex/Adjustable/Class.hs
+++ b/src/Reflex/Adjustable/Class.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+#ifdef USE_REFLEX_OPTIMIZER
+{-# OPTIONS_GHC -fplugin=Reflex.Optimizer #-}
+#endif
+module Reflex.Adjustable.Class 
+  ( 
+  -- * The Adjustable typeclass
+    Adjustable(..)
+  , sequenceDMapWithAdjust
+  , sequenceDMapWithAdjustWithMove
+  , mapMapWithAdjustWithMove
+  -- * Widgets on Collections
+  , listHoldWithKey
+  , listWithKey
+  , listWithKey'
+  , listWithKeyShallowDiff
+  , listViewWithKey
+  , selectViewListWithKey
+  , selectViewListWithKey_
+  -- * List Utils
+  , list
+  , simpleList
+  ) where
+
+import Control.Monad.Identity hiding (forM, forM_, mapM, mapM_, sequence, sequence_)
+import Control.Monad.Reader hiding (forM, forM_, mapM, mapM_, sequence, sequence_)
+import Data.Align
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Dependent.Map (DMap, GCompare (..))
+import Data.Functor.Constant
+import Data.Functor.Misc
+import Data.Map.Misc
+import Data.These
+
+import Reflex.Class
+import Reflex.Dynamic
+import Reflex.PostBuild.Class
+
+-- | A 'Monad' that supports adjustment over time.  After an action has been
+-- run, if the given events fire, it will adjust itself so that its net effect
+-- is as though it had originally been run with the new value.  Note that there
+-- is some issue here with persistent side-effects: obviously, IO (and some
+-- other side-effects) cannot be undone, so it is up to the instance implementer
+-- to determine what the best meaning for this class is in such cases.
+class (Reflex t, Monad m) => Adjustable t m | m -> t where
+  runWithReplace :: m a -> Event t (m b) -> m (a, Event t b)
+  traverseIntMapWithKeyWithAdjust :: (IntMap.Key -> v -> m v') -> IntMap v -> Event t (PatchIntMap v) -> m (IntMap v', Event t (PatchIntMap v'))
+  traverseDMapWithKeyWithAdjust :: GCompare k => (forall a. k a -> v a -> m (v' a)) -> DMap k v -> Event t (PatchDMap k v) -> m (DMap k v', Event t (PatchDMap k v'))
+  traverseDMapWithKeyWithAdjustWithMove :: GCompare k => (forall a. k a -> v a -> m (v' a)) -> DMap k v -> Event t (PatchDMapWithMove k v) -> m (DMap k v', Event t (PatchDMapWithMove k v'))
+
+instance Adjustable t m => Adjustable t (ReaderT r m) where
+  runWithReplace a0 a' = do
+    r <- ask
+    lift $ runWithReplace (runReaderT a0 r) $ fmap (`runReaderT` r) a'
+  traverseIntMapWithKeyWithAdjust f dm0 dm' = do
+    r <- ask
+    lift $ traverseIntMapWithKeyWithAdjust (\k v -> runReaderT (f k v) r) dm0 dm'
+  traverseDMapWithKeyWithAdjust f dm0 dm' = do
+    r <- ask
+    lift $ traverseDMapWithKeyWithAdjust (\k v -> runReaderT (f k v) r) dm0 dm'
+  traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = do
+    r <- ask
+    lift $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runReaderT (f k v) r) dm0 dm'
+
+sequenceDMapWithAdjust :: (GCompare k, Adjustable t m) => DMap k m -> Event t (PatchDMap k m) -> m (DMap k Identity, Event t (PatchDMap k Identity))
+sequenceDMapWithAdjust = traverseDMapWithKeyWithAdjust $ \_ -> fmap Identity
+
+sequenceDMapWithAdjustWithMove :: (GCompare k, Adjustable t m) => DMap k m -> Event t (PatchDMapWithMove k m) -> m (DMap k Identity, Event t (PatchDMapWithMove k Identity))
+sequenceDMapWithAdjustWithMove = traverseDMapWithKeyWithAdjustWithMove $ \_ -> fmap Identity
+
+mapMapWithAdjustWithMove :: forall t m k v v'. (Adjustable t m, Ord k) => (k -> v -> m v') -> Map k v -> Event t (PatchMapWithMove k v) -> m (Map k v', Event t (PatchMapWithMove k v'))
+mapMapWithAdjustWithMove f m0 m' = do
+  (out0 :: DMap (Const2 k v) (Constant v'), out') <- traverseDMapWithKeyWithAdjustWithMove (\(Const2 k) (Identity v) -> Constant <$> f k v) (mapToDMap m0) (const2PatchDMapWithMoveWith Identity <$> m')
+  return (dmapToMapWith (\(Constant v') -> v') out0, patchDMapWithMoveToPatchMapWithMoveWith (\(Constant v') -> v') <$> out')
+
+listHoldWithKey :: forall t m k v a. (Ord k, Adjustable t m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> m a) -> m (Dynamic t (Map k a))
+listHoldWithKey m0 m' f = do
+  let dm0 = mapWithFunctorToDMap $ Map.mapWithKey f m0
+      dm' = fmap (PatchDMap . mapWithFunctorToDMap . Map.mapWithKey (\k v -> ComposeMaybe $ fmap (f k) v)) m'
+  (a0, a') <- sequenceDMapWithAdjust dm0 dm'
+  fmap dmapToMap . incrementalToDynamic <$> holdIncremental a0 a' --TODO: Move the dmapToMap to the righthand side so it doesn't get fully redone every time
+
+--TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
+listWithKey :: forall t k v m a. (Ord k, Adjustable t m, PostBuild t m, MonadFix m, MonadHold t m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Dynamic t (Map k a))
+listWithKey vals mkChild = do
+  postBuild <- getPostBuild
+  let childValChangedSelector = fanMap $ updated vals
+      -- We keep track of changes to children values in the mkChild function we pass to listHoldWithKey
+      -- The other changes we need to keep track of are child insertions and deletions. diffOnlyKeyChanges
+      -- keeps track of insertions and deletions but ignores value changes, since they're already accounted for.
+      diffOnlyKeyChanges olds news = flip Map.mapMaybe (align olds news) $ \case
+        This _ -> Just Nothing
+        These _ _ -> Nothing
+        That new -> Just $ Just new
+  rec sentVals :: Dynamic t (Map k v) <- foldDyn applyMap Map.empty changeVals
+      let changeVals :: Event t (Map k (Maybe v))
+          changeVals = attachWith diffOnlyKeyChanges (current sentVals) $ leftmost
+                         [ updated vals
+                         , tag (current vals) postBuild --TODO: This should probably be added to the attachWith, not to the updated; if we were using diffMap instead of diffMapNoEq, I think it might not work
+                         ]
+  listHoldWithKey Map.empty changeVals $ \k v ->
+    mkChild k =<< holdDyn v (select childValChangedSelector $ Const2 k)
+
+{-# DEPRECATED listWithKey' "listWithKey' has been renamed to listWithKeyShallowDiff; also, its behavior has changed to fix a bug where children were always rebuilt (never updated)" #-}
+listWithKey' :: (Ord k, Adjustable t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
+listWithKey' = listWithKeyShallowDiff
+
+-- | Display the given map of items (in key order) using the builder function provided, and update it with the given event.  'Nothing' update entries will delete the corresponding children, and 'Just' entries will create them if they do not exist or send an update event to them if they do.
+listWithKeyShallowDiff :: (Ord k, Adjustable t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
+listWithKeyShallowDiff initialVals valsChanged mkChild = do
+  let childValChangedSelector = fanMap $ fmap (Map.mapMaybe id) valsChanged
+  sentVals <- foldDyn applyMap Map.empty $ fmap (fmap void) valsChanged
+  let relevantPatch patch _ = case patch of
+        Nothing -> Just Nothing -- Even if we let a Nothing through when the element doesn't already exist, this doesn't cause a problem because it is ignored
+        Just _ -> Nothing -- We don't want to let spurious re-creations of items through
+  listHoldWithKey initialVals (attachWith (flip (Map.differenceWith relevantPatch)) (current sentVals) valsChanged) $ \k v ->
+    mkChild k v $ select childValChangedSelector $ Const2 k
+
+--TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
+-- | Create a dynamically-changing set of Event-valued widgets.
+--   This is like listWithKey, specialized for widgets returning (Event t a).  listWithKey would return 'Dynamic t (Map k (Event t a))' in this scenario, but listViewWithKey flattens this to 'Event t (Map k a)' via 'switch'.
+listViewWithKey :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m (Event t a)) -> m (Event t (Map k a))
+listViewWithKey vals mkChild = switch . fmap mergeMap <$> listViewWithKey' vals mkChild
+
+listViewWithKey' :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Behavior t (Map k a))
+listViewWithKey' vals mkChild = current <$> listWithKey vals mkChild
+
+-- | Create a dynamically-changing set of widgets, one of which is selected at any time.
+selectViewListWithKey :: forall t m k v a. (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
+  => Dynamic t k          -- ^ Current selection key
+  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
+  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
+  -> m (Event t (k, a))        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
+selectViewListWithKey selection vals mkChild = do
+  let selectionDemux = demux selection -- For good performance, this value must be shared across all children
+  selectChild <- listWithKey vals $ \k v -> do
+    let selected = demuxed selectionDemux k
+    selectSelf <- mkChild k v selected
+    return $ fmap ((,) k) selectSelf
+  return $ switchPromptlyDyn $ leftmost . Map.elems <$> selectChild
+
+selectViewListWithKey_ :: forall t m k v a. (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
+  => Dynamic t k          -- ^ Current selection key
+  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
+  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
+  -> m (Event t k)        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
+selectViewListWithKey_ selection vals mkChild = fmap fst <$> selectViewListWithKey selection vals mkChild
+
+-- | Create a dynamically-changing set of widgets from a Dynamic key/value map.
+--   Unlike the 'withKey' variants, the child widgets are insensitive to which key they're associated with.
+list :: (Ord k, Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t (Map k v) -> (Dynamic t v -> m a) -> m (Dynamic t (Map k a))
+list dm mkChild = listWithKey dm (\_ dv -> mkChild dv)
+
+-- | Create a dynamically-changing set of widgets from a Dynamic list.
+simpleList :: (Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t [v] -> (Dynamic t v -> m a) -> m (Dynamic t [a])
+simpleList xs mkChild = fmap (fmap (map snd . Map.toList)) $ flip list mkChild $ fmap (Map.fromList . zip [(1::Int)..]) xs

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -120,13 +121,15 @@ module Reflex.Class
   , ffilter
   , filterLeft
   , filterRight
-    -- * Miscellaneous convenience functions
-  , ffor
-  , MonadAdjust (..)
+   -- * 'Adjustable'
+  , Adjustable(..)
   , sequenceDMapWithAdjust
   , sequenceDMapWithAdjustWithMove
   , mapMapWithAdjustWithMove
+    -- * Miscellaneous convenience functions
+  , ffor
     -- * Deprecated functions
+  , MonadAdjust
   , appendEvents
   , onceE
   , sequenceThese
@@ -1154,19 +1157,23 @@ infixl 4 <@>
 (<@) = tag
 infixl 4 <@
 
+------------------
+-- Adjustable
+------------------
+
 -- | A 'Monad' that supports adjustment over time.  After an action has been
 -- run, if the given events fire, it will adjust itself so that its net effect
 -- is as though it had originally been run with the new value.  Note that there
 -- is some issue here with persistent side-effects: obviously, IO (and some
 -- other side-effects) cannot be undone, so it is up to the instance implementer
 -- to determine what the best meaning for this class is in such cases.
-class (Reflex t, Monad m) => MonadAdjust t m | m -> t where
+class (Reflex t, Monad m) => Adjustable t m | m -> t where
   runWithReplace :: m a -> Event t (m b) -> m (a, Event t b)
   traverseIntMapWithKeyWithAdjust :: (IntMap.Key -> v -> m v') -> IntMap v -> Event t (PatchIntMap v) -> m (IntMap v', Event t (PatchIntMap v'))
   traverseDMapWithKeyWithAdjust :: GCompare k => (forall a. k a -> v a -> m (v' a)) -> DMap k v -> Event t (PatchDMap k v) -> m (DMap k v', Event t (PatchDMap k v'))
   traverseDMapWithKeyWithAdjustWithMove :: GCompare k => (forall a. k a -> v a -> m (v' a)) -> DMap k v -> Event t (PatchDMapWithMove k v) -> m (DMap k v', Event t (PatchDMapWithMove k v'))
 
-instance MonadAdjust t m => MonadAdjust t (ReaderT r m) where
+instance Adjustable t m => Adjustable t (ReaderT r m) where
   runWithReplace a0 a' = do
     r <- ask
     lift $ runWithReplace (runReaderT a0 r) $ fmap (`runReaderT` r) a'
@@ -1180,13 +1187,13 @@ instance MonadAdjust t m => MonadAdjust t (ReaderT r m) where
     r <- ask
     lift $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runReaderT (f k v) r) dm0 dm'
 
-sequenceDMapWithAdjust :: (GCompare k, MonadAdjust t m) => DMap k m -> Event t (PatchDMap k m) -> m (DMap k Identity, Event t (PatchDMap k Identity))
+sequenceDMapWithAdjust :: (GCompare k, Adjustable t m) => DMap k m -> Event t (PatchDMap k m) -> m (DMap k Identity, Event t (PatchDMap k Identity))
 sequenceDMapWithAdjust = traverseDMapWithKeyWithAdjust $ \_ -> fmap Identity
 
-sequenceDMapWithAdjustWithMove :: (GCompare k, MonadAdjust t m) => DMap k m -> Event t (PatchDMapWithMove k m) -> m (DMap k Identity, Event t (PatchDMapWithMove k Identity))
+sequenceDMapWithAdjustWithMove :: (GCompare k, Adjustable t m) => DMap k m -> Event t (PatchDMapWithMove k m) -> m (DMap k Identity, Event t (PatchDMapWithMove k Identity))
 sequenceDMapWithAdjustWithMove = traverseDMapWithKeyWithAdjustWithMove $ \_ -> fmap Identity
 
-mapMapWithAdjustWithMove :: forall t m k v v'. (MonadAdjust t m, Ord k) => (k -> v -> m v') -> Map k v -> Event t (PatchMapWithMove k v) -> m (Map k v', Event t (PatchMapWithMove k v'))
+mapMapWithAdjustWithMove :: forall t m k v v'. (Adjustable t m, Ord k) => (k -> v -> m v') -> Map k v -> Event t (PatchMapWithMove k v) -> m (Map k v', Event t (PatchMapWithMove k v'))
 mapMapWithAdjustWithMove f m0 m' = do
   (out0 :: DMap (Const2 k v) (Constant v'), out') <- traverseDMapWithKeyWithAdjustWithMove (\(Const2 k) (Identity v) -> Constant <$> f k v) (mapToDMap m0) (const2PatchDMapWithMoveWith Identity <$> m')
   return (dmapToMapWith (\(Constant v') -> v') out0, patchDMapWithMoveToPatchMapWithMoveWith (\(Constant v') -> v') <$> out')
@@ -1238,6 +1245,9 @@ mergeWithFoldCheap' f es =
 --------------------------------------------------------------------------------
 -- Deprecated functions
 --------------------------------------------------------------------------------
+
+{-# DEPRECATED MonadAdjust "Use Adjustable instead" #-}
+type MonadAdjust = Adjustable
 
 -- | Create a new 'Event' that occurs if at least one of the supplied 'Event's
 -- occurs. If both occur at the same time they are combined using 'mappend'.

--- a/src/Reflex/Collection.hs
+++ b/src/Reflex/Collection.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+#ifdef USE_REFLEX_OPTIMIZER
+{-# OPTIONS_GHC -fplugin=Reflex.Optimizer #-}
+#endif
+module Reflex.Collection
+  ( 
+  -- * Widgets on Collections
+    listHoldWithKey
+  , listWithKey
+  , listWithKey'
+  , listWithKeyShallowDiff
+  , listViewWithKey
+  , selectViewListWithKey
+  , selectViewListWithKey_
+  -- * List Utils
+  , list
+  , simpleList
+  ) where
+
+import Control.Monad.Identity hiding (forM, forM_, mapM, mapM_, sequence, sequence_)
+import Data.Align
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Functor.Misc
+import Data.Map.Misc
+import Data.These
+
+import Reflex.Class
+import Reflex.Dynamic
+import Reflex.PostBuild.Class
+
+listHoldWithKey :: forall t m k v a. (Ord k, Adjustable t m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> m a) -> m (Dynamic t (Map k a))
+listHoldWithKey m0 m' f = do
+  let dm0 = mapWithFunctorToDMap $ Map.mapWithKey f m0
+      dm' = fmap (PatchDMap . mapWithFunctorToDMap . Map.mapWithKey (\k v -> ComposeMaybe $ fmap (f k) v)) m'
+  (a0, a') <- sequenceDMapWithAdjust dm0 dm'
+  fmap dmapToMap . incrementalToDynamic <$> holdIncremental a0 a' --TODO: Move the dmapToMap to the righthand side so it doesn't get fully redone every time
+
+--TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
+listWithKey :: forall t k v m a. (Ord k, Adjustable t m, PostBuild t m, MonadFix m, MonadHold t m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Dynamic t (Map k a))
+listWithKey vals mkChild = do
+  postBuild <- getPostBuild
+  let childValChangedSelector = fanMap $ updated vals
+      -- We keep track of changes to children values in the mkChild function we pass to listHoldWithKey
+      -- The other changes we need to keep track of are child insertions and deletions. diffOnlyKeyChanges
+      -- keeps track of insertions and deletions but ignores value changes, since they're already accounted for.
+      diffOnlyKeyChanges olds news = flip Map.mapMaybe (align olds news) $ \case
+        This _ -> Just Nothing
+        These _ _ -> Nothing
+        That new -> Just $ Just new
+  rec sentVals :: Dynamic t (Map k v) <- foldDyn applyMap Map.empty changeVals
+      let changeVals :: Event t (Map k (Maybe v))
+          changeVals = attachWith diffOnlyKeyChanges (current sentVals) $ leftmost
+                         [ updated vals
+                         , tag (current vals) postBuild --TODO: This should probably be added to the attachWith, not to the updated; if we were using diffMap instead of diffMapNoEq, I think it might not work
+                         ]
+  listHoldWithKey Map.empty changeVals $ \k v ->
+    mkChild k =<< holdDyn v (select childValChangedSelector $ Const2 k)
+
+{-# DEPRECATED listWithKey' "listWithKey' has been renamed to listWithKeyShallowDiff; also, its behavior has changed to fix a bug where children were always rebuilt (never updated)" #-}
+listWithKey' :: (Ord k, Adjustable t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
+listWithKey' = listWithKeyShallowDiff
+
+-- | Display the given map of items (in key order) using the builder function provided, and update it with the given event.  'Nothing' update entries will delete the corresponding children, and 'Just' entries will create them if they do not exist or send an update event to them if they do.
+listWithKeyShallowDiff :: (Ord k, Adjustable t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
+listWithKeyShallowDiff initialVals valsChanged mkChild = do
+  let childValChangedSelector = fanMap $ fmap (Map.mapMaybe id) valsChanged
+  sentVals <- foldDyn applyMap Map.empty $ fmap (fmap void) valsChanged
+  let relevantPatch patch _ = case patch of
+        Nothing -> Just Nothing -- Even if we let a Nothing through when the element doesn't already exist, this doesn't cause a problem because it is ignored
+        Just _ -> Nothing -- We don't want to let spurious re-creations of items through
+  listHoldWithKey initialVals (attachWith (flip (Map.differenceWith relevantPatch)) (current sentVals) valsChanged) $ \k v ->
+    mkChild k v $ select childValChangedSelector $ Const2 k
+
+--TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
+-- | Create a dynamically-changing set of Event-valued widgets.
+--   This is like listWithKey, specialized for widgets returning (Event t a).  listWithKey would return 'Dynamic t (Map k (Event t a))' in this scenario, but listViewWithKey flattens this to 'Event t (Map k a)' via 'switch'.
+listViewWithKey :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m (Event t a)) -> m (Event t (Map k a))
+listViewWithKey vals mkChild = switch . fmap mergeMap <$> listViewWithKey' vals mkChild
+
+listViewWithKey' :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Behavior t (Map k a))
+listViewWithKey' vals mkChild = current <$> listWithKey vals mkChild
+
+-- | Create a dynamically-changing set of widgets, one of which is selected at any time.
+selectViewListWithKey :: forall t m k v a. (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
+  => Dynamic t k          -- ^ Current selection key
+  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
+  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
+  -> m (Event t (k, a))        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
+selectViewListWithKey selection vals mkChild = do
+  let selectionDemux = demux selection -- For good performance, this value must be shared across all children
+  selectChild <- listWithKey vals $ \k v -> do
+    let selected = demuxed selectionDemux k
+    selectSelf <- mkChild k v selected
+    return $ fmap ((,) k) selectSelf
+  return $ switchPromptlyDyn $ leftmost . Map.elems <$> selectChild
+
+selectViewListWithKey_ :: forall t m k v a. (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
+  => Dynamic t k          -- ^ Current selection key
+  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
+  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
+  -> m (Event t k)        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
+selectViewListWithKey_ selection vals mkChild = fmap fst <$> selectViewListWithKey selection vals mkChild
+
+-- | Create a dynamically-changing set of widgets from a Dynamic key/value map.
+--   Unlike the 'withKey' variants, the child widgets are insensitive to which key they're associated with.
+list :: (Ord k, Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t (Map k v) -> (Dynamic t v -> m a) -> m (Dynamic t (Map k a))
+list dm mkChild = listWithKey dm (\_ dv -> mkChild dv)
+
+-- | Create a dynamically-changing set of widgets from a Dynamic list.
+simpleList :: (Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t [v] -> (Dynamic t v -> m a) -> m (Dynamic t [a])
+simpleList xs mkChild = fmap (fmap (map snd . Map.toList)) $ flip list mkChild $ fmap (Map.fromList . zip [(1::Int)..]) xs

--- a/src/Reflex/DynamicWriter.hs
+++ b/src/Reflex/DynamicWriter.hs
@@ -135,9 +135,9 @@ instance MonadState s m => MonadState s (DynamicWriterT t w m) where
 newtype DynamicWriterTLoweredResult t w v a = DynamicWriterTLoweredResult (v a, Dynamic t w)
 
 -- | When the execution of a 'DynamicWriterT' action is adjusted using
--- 'MonadAdjust', the 'Dynamic' output of that action will also be updated to
+-- 'Adjustable', the 'Dynamic' output of that action will also be updated to
 -- match.
-instance (MonadAdjust t m, MonadFix m, Monoid w, MonadHold t m, Reflex t) => MonadAdjust t (DynamicWriterT t w m) where
+instance (Adjustable t m, MonadFix m, Monoid w, MonadHold t m, Reflex t) => Adjustable t (DynamicWriterT t w m) where
   runWithReplace a0 a' = do
     (result0, result') <- lift $ runWithReplace (runDynamicWriterT a0) $ runDynamicWriterT <$> a'
     tellDyn . join =<< holdDyn (snd result0) (snd <$> result')

--- a/src/Reflex/EventWriter.hs
+++ b/src/Reflex/EventWriter.hs
@@ -140,7 +140,7 @@ instance MonadHold t m => MonadHold t (EventWriterT t w m) where
   {-# INLINABLE headE #-}
   headE = lift . headE
 
-instance (Reflex t, MonadAdjust t m, MonadHold t m, Semigroup w) => MonadAdjust t (EventWriterT t w m) where
+instance (Reflex t, Adjustable t m, MonadHold t m, Semigroup w) => Adjustable t (EventWriterT t w m) where
   runWithReplace = runWithReplaceEventWriterTWith $ \dm0 dm' -> lift $ runWithReplace dm0 dm'
   traverseIntMapWithKeyWithAdjust = sequenceIntMapWithAdjustEventWriterTWith (\f dm0 dm' -> lift $ traverseIntMapWithKeyWithAdjust f dm0 dm') patchIntMapNewElements mergeIntIncremental
   traverseDMapWithKeyWithAdjust = sequenceDMapWithAdjustEventWriterTWith (\f dm0 dm' -> lift $ traverseDMapWithKeyWithAdjust f dm0 dm') mapPatchDMap weakenPatchDMapWith patchMapNewElements mergeMapIncremental
@@ -154,8 +154,8 @@ instance Requester t m => Requester t (EventWriterT t w m) where
 
 -- | Given a function like 'runWithReplace' for the underlying monad, implement
 -- 'runWithReplace' for 'EventWriterT'.  This is necessary when the underlying
--- monad doesn't have a 'MonadAdjust' instance or to override the default
--- 'MonadAdjust' behavior.
+-- monad doesn't have a 'Adjustable' instance or to override the default
+-- 'Adjustable' behavior.
 runWithReplaceEventWriterTWith :: forall m t w a b. (Reflex t, MonadHold t m, Semigroup w)
                                => (forall a' b'. m a' -> Event t (m b') -> EventWriterT t w m (a', Event t b'))
                                -> EventWriterT t w m a

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -72,7 +72,7 @@ instance (ReflexHost t, Ref m ~ Ref IO, PrimMonad (HostFrame t)) => PerformEvent
   {-# INLINABLE performEvent #-}
   performEvent = PerformEventT . requestingIdentity
 
-instance (ReflexHost t, PrimMonad (HostFrame t)) => MonadAdjust t (PerformEventT t m) where
+instance (ReflexHost t, PrimMonad (HostFrame t)) => Adjustable t (PerformEventT t m) where
   runWithReplace outerA0 outerA' = PerformEventT $ runWithReplaceRequesterTWith f (coerce outerA0) (coerceEvent outerA')
     where f :: HostFrame t a -> Event t (HostFrame t b) -> RequesterT t (HostFrame t) Identity (HostFrame t) (a, Event t b)
           f a0 a' = do

--- a/src/Reflex/PostBuild/Base.hs
+++ b/src/Reflex/PostBuild/Base.hs
@@ -107,7 +107,7 @@ instance MonadAtomicRef m => MonadAtomicRef (PostBuildT t m) where
   {-# INLINABLE atomicModifyRef #-}
   atomicModifyRef r = lift . atomicModifyRef r
 
-instance (Reflex t, MonadHold t m, MonadFix m, MonadAdjust t m, PerformEvent t m) => MonadAdjust t (PostBuildT t m) where
+instance (Reflex t, MonadHold t m, MonadFix m, Adjustable t m, PerformEvent t m) => Adjustable t (PostBuildT t m) where
   runWithReplace a0 a' = do
     postBuild <- getPostBuild
     lift $ do

--- a/src/Reflex/Query/Base.hs
+++ b/src/Reflex/Query/Base.hs
@@ -70,7 +70,7 @@ let sampleBs :: forall m'. MonadSample t m' => [Behavior t q] -> m' q
         return (Just (AdditivePatch p))
 -}
 
-instance (Reflex t, MonadFix m, Group q, Additive q, Query q, MonadHold t m, MonadAdjust t m) => MonadAdjust t (QueryT t q m) where
+instance (Reflex t, MonadFix m, Group q, Additive q, Query q, MonadHold t m, Adjustable t m) => Adjustable t (QueryT t q m) where
   runWithReplace (QueryT a0) a' = do
     ((r0, bs0), r') <- QueryT $ lift $ runWithReplace (runStateT a0 []) $ fmapCheap (flip runStateT [] . unQueryT) a'
     let sampleBs :: forall m'. MonadSample t m' => [Behavior t q] -> m' q

--- a/src/Reflex/Requester/Base.hs
+++ b/src/Reflex/Requester/Base.hs
@@ -299,7 +299,7 @@ instance MonadReader r m => MonadReader r (RequesterT t request response m) wher
   local f (RequesterT a) = RequesterT $ mapStateT (mapReaderT $ local f) a
   reader = lift . reader
 
-instance (Reflex t, MonadAdjust t m, MonadHold t m, MonadFix m) => MonadAdjust t (RequesterT t request response m) where
+instance (Reflex t, Adjustable t m, MonadHold t m, MonadFix m) => Adjustable t (RequesterT t request response m) where
   runWithReplace = runWithReplaceRequesterTWith $ \dm0 dm' -> lift $ runWithReplace dm0 dm'
   traverseIntMapWithKeyWithAdjust = traverseIntMapWithKeyWithAdjustRequesterTWith (\f dm0 dm' -> lift $ traverseIntMapWithKeyWithAdjust f dm0 dm') patchIntMapNewElementsMap mergeIntIncremental
   {-# INLINABLE traverseDMapWithKeyWithAdjust #-}
@@ -358,7 +358,7 @@ traverseIntMapWithKeyWithAdjustRequesterTWith base patchNewElements mergePatchIn
             (result, myRequests) <- runRequesterT (f k v) $ fmapMaybeCheap (IntMap.lookup n) $ selectInt responses k --TODO: Instead of doing fmapMaybeCheap, can we share a fanInt across all instances of a given key, or at least the ones that are adjacent in time?
             return (fmapCheap (IntMap.singleton n) myRequests, result)
       ndm' <- numberOccurrencesFrom 1 dm'
-      (children0, children') <- base f' (fmap ((,) 0) dm0) $ fmap (\(n, dm) -> fmap ((,) n) dm) ndm' --TODO: Avoid this somehow, probably by adding some sort of per-cohort information passing to MonadAdjust
+      (children0, children') <- base f' (fmap ((,) 0) dm0) $ fmap (\(n, dm) -> fmap ((,) n) dm) ndm' --TODO: Avoid this somehow, probably by adding some sort of per-cohort information passing to Adjustable
       let result0 = fmap snd children0
           result' = fforCheap children' $ fmap snd
           requests0 :: IntMap (Event t (IntMap (RequesterData request)))

--- a/src/Reflex/TriggerEvent/Base.hs
+++ b/src/Reflex/TriggerEvent/Base.hs
@@ -119,7 +119,7 @@ instance MonadHold t m => MonadHold t (TriggerEventT t m) where
   {-# INLINABLE headE #-}
   headE = lift . headE
 
-instance MonadAdjust t m => MonadAdjust t (TriggerEventT t m) where
+instance Adjustable t m => Adjustable t (TriggerEventT t m) where
   {-# INLINABLE runWithReplace #-}
   runWithReplace (TriggerEventT a0) a' = TriggerEventT $ runWithReplace a0 (coerceEvent a')
   {-# INLINABLE traverseIntMapWithKeyWithAdjust #-}

--- a/src/Reflex/Widget/Basic.hs
+++ b/src/Reflex/Widget/Basic.hs
@@ -30,7 +30,7 @@ import Reflex.Patch.MapWithMove
 -- >   (\k v -> text $ "\n" ++ show k ++ " " ++ v)  -- show each element on a new line
 -- >   (Map.fromList $ zip [0..] [(3, "a"), (2, "b"), (1, "c")])
 -- >   sortEvent
-sortableList :: forall t m k v a. (MonadHold t m, MonadFix m, MonadAdjust t m, Ord k)
+sortableList :: forall t m k v a. (MonadHold t m, MonadFix m, Adjustable t m, Ord k)
              => (k -> v -> m a) -- ^ Function to render the content for each key/value pair
              -> Map k v -- ^ The sortable list with an initial ordering determined by the @Map@ keys in ascending order
              -> Event t (v -> v -> Ordering) -- ^ An event carrying a sort function for the list

--- a/test/EventWriterT.hs
+++ b/test/EventWriterT.hs
@@ -35,7 +35,7 @@ testOrdering pulse = do
   forM_ [10,9..1] $ \i -> tellEvent ([i] <$ pulse)
   return ()
 
-testSimultaneous :: (Reflex t, MonadAdjust t m, MonadHold t m) => Event t (These () ()) -> EventWriterT t [Int] m ()
+testSimultaneous :: (Reflex t, Adjustable t m, MonadHold t m) => Event t (These () ()) -> EventWriterT t [Int] m ()
 testSimultaneous pulse = do
   let e0 = fmapMaybe (^? here) pulse
       e1 = fmapMaybe (^? there) pulse

--- a/test/RequesterT.hs
+++ b/test/RequesterT.hs
@@ -45,7 +45,7 @@ unwrapApp x appIn = do
 testOrdering :: ( Response m ~ Identity
                 , Request m ~ RequestInt
                 , Requester t m
-                , MonadAdjust t m)
+                , Adjustable t m)
              => Event t ()
              -> m ()
 testOrdering pulse = do
@@ -55,7 +55,7 @@ testOrdering pulse = do
 testSimultaneous :: ( Response m ~ Identity
                     , Request m ~ RequestInt
                     , Requester t m
-                    , MonadAdjust t m)
+                    , Adjustable t m)
                  => Event t (These () ())
                  -> m ()
 testSimultaneous pulse = do


### PR DESCRIPTION
This also brings the collection management functions across from `reflex-dom` - there is a companion PR in `reflex-dom` dealing with this [here](https://github.com/reflex-frp/reflex-dom/pull/163).