### PR TITLE
remove hlint bound

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -180,7 +180,7 @@ test-suite hlint
                , directory
                , filepath
                , filemanip
-               , hlint == 1.9.*
+               , hlint
   if impl(ghcjs)
     buildable: False
 

--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 import Control.Lens


### PR DESCRIPTION
Tests run successfully on hlint 2.0.9 (currently in nixpkgs) so the bound does not seem necessary.