### PR TITLE
Moves Workflow across from reflex-dom

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -94,6 +94,8 @@ library
     Reflex.FastWeak,
     Reflex.FunctorMaybe,
     Reflex.Host.Class,
+    Reflex.Network,
+    Reflex.NotReady.Class,
     Reflex.Patch,
     Reflex.Patch.Class,
     Reflex.Patch.DMap,
@@ -114,7 +116,8 @@ library
     Reflex.Spider,
     Reflex.Spider.Internal,
     Reflex.Time,
-    Reflex.Widget.Basic
+    Reflex.Widget.Basic,
+    Reflex.Workflow
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2 -fspecialise-aggressively -ddump-simpl -ddump-to-file -dsuppress-coercions -dsuppress-idinfo
   ghc-prof-options: -fprof-auto

--- a/src/Reflex/Network.hs
+++ b/src/Reflex/Network.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+#ifdef USE_REFLEX_OPTIMIZER
+{-# OPTIONS_GHC -fplugin=Reflex.Optimizer #-}
+#endif
+module Reflex.Network
+  ( networkView
+  , networkHold
+  , untilReady
+  ) where
+
+import Reflex.Class
+import Reflex.NotReady.Class
+import Reflex.PostBuild.Class
+
+-- | Given a Dynamic of network-creating actions, create a network that is recreated whenever the Dynamic updates.
+--   The returned Event of network results occurs when the Dynamic does.
+--   Note:  Often, the type 'a' is an Event, in which case the return value is an Event-of-Events that would typically be flattened (via 'switchPromptly').
+networkView :: (Reflex t, NotReady t m, Adjustable t m, PostBuild t m) => Dynamic t (m a) -> m (Event t a)
+networkView child = do
+  postBuild <- getPostBuild
+  let newChild = leftmost [updated child, tagCheap (current child) postBuild]
+  snd <$> runWithReplace notReady newChild
+
+-- | Given an initial network and an Event of network-creating actions, create a network that is recreated whenever the Event fires.
+--   The returned Dynamic of network results occurs when the Event does.
+--   Note:  Often, the type 'a' is an Event, in which case the return value is a Dynamic-of-Events that would typically be flattened.
+networkHold :: (Reflex t, Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m (Dynamic t a)
+networkHold child0 newChild = do
+  (result0, newResult) <- runWithReplace child0 newChild
+  holdDyn result0 newResult
+
+-- | Render a placeholder network to be shown while another network is not yet
+-- done building
+untilReady :: (Reflex t, Adjustable t m, PostBuild t m) => m a -> m b -> m (a, Event t b)
+untilReady a b = do
+  postBuild <- getPostBuild
+  runWithReplace a $ b <$ postBuild

--- a/src/Reflex/NotReady/Class.hs
+++ b/src/Reflex/NotReady/Class.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+#ifdef USE_REFLEX_OPTIMIZER
+{-# OPTIONS_GHC -fplugin=Reflex.Optimizer #-}
+#endif
+module Reflex.NotReady.Class
+  ( NotReady(..)
+  ) where
+
+import Control.Monad.Trans
+import Control.Monad.Reader (ReaderT)
+
+import Reflex.Class
+import Reflex.Host.Class
+import Reflex.PostBuild.Base (PostBuildT)
+import Reflex.EventWriter (EventWriterT)
+import Reflex.DynamicWriter (DynamicWriterT)
+import Reflex.Query.Base (QueryT)
+import Reflex.Requester.Base (RequesterT)
+import Reflex.PerformEvent.Base (PerformEventT(..))
+import Reflex.TriggerEvent.Base (TriggerEventT)
+
+class Monad m => NotReady t m | m -> t where
+  notReadyUntil :: Event t a -> m ()
+  default notReadyUntil :: (MonadTrans f, m ~ f m', NotReady t m') => Event t a -> m ()
+  notReadyUntil = lift . notReadyUntil
+
+  notReady :: m ()
+  default notReady :: (MonadTrans f, m ~ f m', NotReady t m') => m ()
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (ReaderT r m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (PostBuildT t m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (EventWriterT t w m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (DynamicWriterT t w m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (QueryT t q m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance (ReflexHost t, NotReady t (HostFrame t)) => NotReady t (PerformEventT t m) where
+  notReadyUntil = PerformEventT . notReadyUntil
+  notReady = PerformEventT notReady
+
+instance NotReady t m => NotReady t (RequesterT t request response m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance NotReady t m => NotReady t (TriggerEventT t m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -89,6 +89,7 @@ import qualified Reflex.Class
 import qualified Reflex.Class as R
 import qualified Reflex.Host.Class
 #endif
+import Reflex.NotReady.Class
 import Reflex.Patch
 import qualified Reflex.Patch.DMapWithMove as PatchDMapWithMove
 
@@ -2418,6 +2419,10 @@ instance Monad (SpiderHostFrame x) where
   return x = SpiderHostFrame $ return x
   {-# INLINABLE fail #-}
   fail s = SpiderHostFrame $ fail s
+
+instance NotReady x (SpiderHostFrame x) where
+  notReadyUntil _ = pure ()
+  notReady = pure ()
 
 newEventWithTriggerIO :: (RootTrigger x a -> IO (IO ())) -> IO (Event x a)
 newEventWithTriggerIO f = do

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecursiveDo #-}
+module Reflex.Workflow (
+  -- * Workflows
+    Workflow (..)
+  , workflow
+  , workflowView
+  , mapWorkflow
+  , mapWorkflowCheap
+  ) where
+
+import Control.Arrow ((***))
+import Control.Monad.Fix (MonadFix)
+
+import Reflex.Class
+import Reflex.Network
+import Reflex.NotReady.Class
+import Reflex.PostBuild.Class
+
+newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) }
+
+workflow :: forall t m a. (Reflex t, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
+workflow w0 = do
+  rec eResult <- networkHold (unWorkflow w0) $ fmap unWorkflow $ switch $ snd <$> current eResult
+  return $ fmap fst eResult
+
+workflowView :: forall t m a. (Reflex t, NotReady t m, Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
+workflowView w0 = do
+  rec eResult <- networkView . fmap unWorkflow =<< holdDyn w0 eReplace
+      eReplace <- fmap switch $ hold never $ fmap snd eResult
+  return $ fmap fst eResult
+
+mapWorkflow :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
+mapWorkflow f (Workflow x) = Workflow (fmap (f *** fmap (mapWorkflow f)) x)
+
+mapWorkflowCheap :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
+mapWorkflowCheap f (Workflow x) = Workflow (fmap (f *** fmapCheap (mapWorkflowCheap f)) x)


### PR DESCRIPTION
This also included moving generalizations of `dyn` and `widgetHold` across from `reflex-dom` and breaking out a `NotReady` class from the `DomBuilder` class.

There is a companion PR in the `reflex-dom` repository [here](https://github.com/reflex-frp/reflex-dom/pull/178).