### PR TITLE
Relaxed haskell-src-exts upper bound for GHC 8.2.1

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -137,7 +137,7 @@ library
     cpp-options: -DUSE_TEMPLATE_HASKELL
     build-depends:
       dependent-sum >= 0.3 && < 0.5,
-      haskell-src-exts >= 1.16 && < 1.19,
+      haskell-src-exts >= 1.16 && < 1.20,
       haskell-src-meta >= 0.6 && < 0.9,
       template-haskell >= 2.9 && < 2.13
     exposed-modules:


### PR DESCRIPTION
The upper bound of `haskell-src-exts` prevented stack from resolving deps on nightly. This bumps the upper bound to include `1.19`, which seems to work.