### PR TITLE
Patch 0.4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 
 Reflex is an fully-deterministic, higher-order Functional Reactive Programming (FRP) interface and an engine that efficiently implements that interface.
 
-[Reflex-DOM](https://github.com/ryantrinkle/reflex-dom) is a framework built on Reflex that facilitates the development of web pages, including highly-interactive single-page apps.
+[Reflex-DOM](https://github.com/reflex-frp/reflex-dom) is a framework built on Reflex that facilitates the development of web pages, including highly-interactive single-page apps.
 
-Comprehensive documentation is still a work in progress, but a tutorial for Reflex and Reflex-DOM is available at https://github.com/ryantrinkle/try-reflex and an introductory talk given at the New York Haskell Meetup is available here: [Part 1](https://www.youtube.com/watch?v=mYvkcskJbc4) / [Part 2](https://www.youtube.com/watch?v=3qfc9XFVo2c).
+Comprehensive documentation is still a work in progress, but a tutorial for Reflex and Reflex-DOM is available at https://github.com/reflex-frp/reflex-platform and an introductory talk given at the New York Haskell Meetup is available here: [Part 1](https://www.youtube.com/watch?v=mYvkcskJbc4) / [Part 2](https://www.youtube.com/watch?v=3qfc9XFVo2c).
 
 A summary of Reflex functions is available in the [quick reference](Quickref.md).
 
 ### Additional resources
-[try reflex](https://github.com/ryantrinkle/try-reflex)
+[Get started with Reflex](https://github.com/reflex-frp/reflex-platform)
 
-[reddit/r/reflexfrp](http://www.reddit.com/r/reflexfrp)
+[/r/reflexfrp](https://www.reddit.com/r/reflexfrp)
 
-[reflex at hackage](https://hackage.haskell.org/package/reflex)
+[hackage](https://hackage.haskell.org/package/reflex)
 
-irc.freenode.net #reflex-frp
+[irc.freenode.net #reflex-frp](http://webchat.freenode.net?channels=%23reflex-frp&uio=d4)

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -29,9 +29,9 @@ library
     exception-transformers == 0.4.*,
     transformers >= 0.2,
     transformers-compat >= 0.3,
-    haskell-src-exts == 1.16.*,
+    haskell-src-exts >= 1.16 && < 1.18,
     haskell-src-meta == 0.6.*,
-    syb == 0.5.*
+    syb >= 0.5 && < 0.7
 
   exposed-modules:
     Reflex,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -24,7 +24,7 @@ library
     containers == 0.5.*,
     these >= 0.4 && < 0.8,
     primitive >= 0.5 && < 0.7,
-    template-haskell >= 2.9 && < 2.12,
+    template-haskell >= 2.9 && < 2.13,
     ref-tf == 0.4.*,
     exception-transformers == 0.4.*,
     transformers >= 0.2,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs: src
   build-depends:
     base >= 4.7 && < 4.10,
-    dependent-sum == 0.3.*,
+    dependent-sum >= 0.3 && < 0.5,
     dependent-map == 0.2.*,
     semigroups >= 0.16 && < 0.19,
     mtl >= 2.1 && < 2.3,
@@ -31,7 +31,7 @@ library
     transformers-compat >= 0.3,
     haskell-src-exts >= 1.16 && < 1.20,
     haskell-src-meta >= 0.6 && < 0.9,
-    syb >= 0.4.4 && < 0.7
+    syb >= 0.4.4 && < 0.8
 
   exposed-modules:
     Reflex,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -10,8 +10,8 @@ Stability: Experimental
 Category: FRP
 Build-type: Simple
 Cabal-version: >=1.9.2
-homepage: https://github.com/ryantrinkle/reflex
-bug-reports: https://github.com/ryantrinkle/reflex/issues
+homepage: https://github.com/reflex-frp/reflex
+bug-reports: https://github.com/reflex-frp/reflex/issues
 
 library
   hs-source-dirs: src
@@ -101,4 +101,4 @@ benchmark saulzar-bench
 
 source-repository head
   type: git
-  location: https://github.com/ryantrinkle/reflex
+  location: https://github.com/reflex-frp/reflex

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -1,5 +1,5 @@
 Name: reflex
-Version: 0.4.0
+Version: 0.4.0.1
 Synopsis: Higher-order Functional Reactive Programming
 Description: Reflex is a high-performance, deterministic, higher-order Functional Reactive Programming system
 License: BSD3

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -16,22 +16,22 @@ bug-reports: https://github.com/reflex-frp/reflex/issues
 library
   hs-source-dirs: src
   build-depends:
-    base >= 4.7 && < 4.9,
+    base >= 4.7 && < 4.10,
     dependent-sum == 0.3.*,
     dependent-map == 0.2.*,
     semigroups >= 0.16 && < 0.19,
     mtl >= 2.1 && < 2.3,
     containers == 0.5.*,
-    these >= 0.4 && < 0.7,
+    these >= 0.4 && < 0.8,
     primitive >= 0.5 && < 0.7,
-    template-haskell >= 2.9 && < 2.11,
+    template-haskell >= 2.9 && < 2.12,
     ref-tf == 0.4.*,
     exception-transformers == 0.4.*,
     transformers >= 0.2,
     transformers-compat >= 0.3,
-    haskell-src-exts >= 1.16 && < 1.18,
-    haskell-src-meta == 0.6.*,
-    syb >= 0.5 && < 0.7
+    haskell-src-exts >= 1.16 && < 1.20,
+    haskell-src-meta >= 0.6 && < 0.9,
+    syb >= 0.4.4 && < 0.7
 
   exposed-modules:
     Reflex,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -71,12 +71,12 @@ benchmark spider-bench
     base,
     dependent-sum,
     dependent-map,
-    transformers >= 0.3 && < 0.5,
+    transformers >= 0.3 && < 0.6,
     stm == 2.4.*,
     deepseq >= 1.3 && < 1.5,
     mtl,
     primitive,
-    criterion == 1.1.*,
+    criterion >= 1.1 && < 1.3,
     reflex
 
 benchmark saulzar-bench
@@ -87,15 +87,15 @@ benchmark saulzar-bench
   build-depends:
     base,
     containers == 0.5.*,
-    ref-tf == 0.4,
+    ref-tf == 0.4.*,
     dependent-sum,
     dependent-map,
-    transformers >= 0.3 && < 0.5,
+    transformers >= 0.3 && < 0.6,
     stm == 2.4.*,
     deepseq >= 1.3 && < 1.5,
     mtl,
     primitive,
-    criterion == 1.1.*,
+    criterion >= 1.1 && < 1.3,
     split,
     reflex
 

--- a/test/Reflex/Plan/Reflex.hs
+++ b/test/Reflex/Plan/Reflex.hs
@@ -24,6 +24,7 @@ import Reflex.TestPlan
 
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Identity
 import Control.Monad.State.Strict
 
 import Data.Dependent.Sum (DSum (..))
@@ -71,8 +72,8 @@ instance (ReflexHost t, MonadRef (HostFrame t), Ref (HostFrame t) ~ Ref IO) => T
       makeFiring ref (t, a) = (fromIntegral t, [Firing ref a])
 
 
-firingTrigger :: (MonadReflexHost t m, MonadIORef m) => Firing t -> m (Maybe (DSum (EventTrigger t)))
-firingTrigger (Firing ref a) = fmap (:=> a) <$> readRef ref
+firingTrigger :: (MonadReflexHost t m, MonadIORef m) => Firing t -> m (Maybe (DSum  (EventTrigger t) Identity))
+firingTrigger (Firing ref a) = fmap (:=> Identity a) <$> readRef ref
 
 runPlan :: (MonadReflexHost t m, MonadIORef m) => Plan t a -> m (a, Schedule t)
 runPlan (Plan p) = runHostFrame $ runStateT p mempty


### PR DESCRIPTION
Primarily intended to support more recent versions of hackage dependencies as described in #149 , but also incorporating the fixes to the benchmarks introduced a bit further along the main branch.

Unfortunately, I was not able to test `template-haskell-2.12:0.0` which is required for full compatibility with `ghc-8.2.1`, as `th-lift-instances` (required indirectly by `haskell-src-meta`) is unable to build with that version. I would appreciate someone checking my work there, though, to be sure I'm not just missing an easy fix to that issue that doesn't involve modifying that code as well.

Finally, I apologise for the overly-large commit list; the branch is based on 77b2a505 (which seems to be the actual code on hackage), but I used a merge to get a small number of lines along with the proper blame annotations, and didn't realize it would pull in the entire history rather than just the few involved commits.