### PR TITLE
Steer people away from `switchPromptly*`

### DIFF
--- a/Quickref.md
+++ b/Quickref.md
@@ -159,7 +159,7 @@ For Events, the returned Event fires whenever the latest Event supplied by the w
 [ ]   switch            ::                  Behavior (Event a)  ->    Event a
 
 -- Flatten Dyanmic-of-Event to Event.  New Event is used immediately.
-[ ]   switchPromptlyDyn ::                   Dynamic (Event a)  ->    Event a
+[ ]   switchDyn         ::                   Dynamic (Event a)  ->    Event a
 
 -- Flatten Event-of-Event to Event that fires when both wrapper AND new Event fire.
 [ ]   coincidence       ::                     Event (Event a)  ->    Event a
@@ -182,7 +182,7 @@ For Events, the returned Event fires whenever the latest Event supplied by the w
 
 -- Similar to above, for Events.  Created Event initially tracks the first argument.
 -- At switchover, the output Event immediately tracks the new Event.
-[H]   switchPromptly    ::       Event a ->    Event (Event a)  -> m (Event a)
+[H]   switchHold        ::       Event a ->    Event (Event a)  -> m (Event a)
 ```
 
 ## Typeclasses to introspect and modify an FRP network.

--- a/test/Reflex/Test/CrossImpl.hs
+++ b/test/Reflex/Test/CrossImpl.hs
@@ -155,35 +155,35 @@ testCases =
        let e' = leftmost [e, e]
        e'' <- switch <$> hold e' (fmap (const e) e)
        return (b, e'')
-  , (,) "switchPromptly-1" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-1" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = fmap (const e) e
-       e'' <- switchPromptly never e'
+       e'' <- switchHoldPromptly never e'
        return (b, e'')
-  , (,) "switchPromptly-2" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-2" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = fmap (const e) e
-       e'' <- switchPromptly never $ leftmost [e', e']
+       e'' <- switchHoldPromptly never $ leftmost [e', e']
        return (b, e'')
-  , (,) "switchPromptly-3" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-3" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = leftmost [e, e]
-       e'' <- switchPromptly never (fmap (const e) e')
+       e'' <- switchHoldPromptly never (fmap (const e) e')
        return (b, e'')
-  , (,) "switchPromptly-4" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj"), (3, "asdf")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-4" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj"), (3, "asdf")]) $ \(b, e) -> do
        let e' = leftmost [e, e]
-       e'' <- switchPromptly never (fmap (const e') e)
+       e'' <- switchHoldPromptly never (fmap (const e') e)
        return (b, e'')
   , (,) "switch-5" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = leftmost [e, e]
        e'' <- switch <$> hold never (fmap (const e') e)
        return (b, e'')
-  , (,) "switchPromptly-5" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-5" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = flip push e $ \_ -> do
              Just <$> headE e
-       e'' <- switchPromptly never e'
+       e'' <- switchHoldPromptly never e'
        return (b, e'')
-  , (,) "switchPromptly-6" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
+  , (,) "switchHoldPromptly-6" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = flip pushAlways e $ \_ -> do
-             switchPromptly e never
-       e'' <- switchPromptly never e'
+             switchHoldPromptly e never
+       e'' <- switchHoldPromptly never e'
        return (b, e'')
   , (,) "coincidence-1" $ TestCase (Map.singleton 0 (0 :: Int), Map.fromList [(1, "qwer"), (2, "lkj")]) $ \(b, e) -> do
        let e' = flip pushAlways e $ \_ -> return e

--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -128,36 +128,36 @@ testCases =
       return $ coincidence $ flip pushAlways e $ const $ do
             switch <$> hold ("x" <$ e) (e <$ e)
 
-  , testE "switchPromptly-1" $ do
+  , testE "switchHoldPromptly-1" $ do
       e <- events1
       let e' = e <$ e
-      switchPromptly never $ e <$ e'
+      switchHoldPromptly never $ e <$ e'
 
-  , testE "switchPromptly-2" $ do
+  , testE "switchHoldPromptly-2" $ do
       e <- events1
-      switchPromptly never $ deep (e <$ e)
+      switchHoldPromptly never $ deep (e <$ e)
 
-  , testE "switchPromptly-3" $ do
+  , testE "switchHoldPromptly-3" $ do
       e <- events1
-      switchPromptly never $ (e <$ deep e)
+      switchHoldPromptly never $ (e <$ deep e)
 
-  , testE "switchPromptly-4" $ do
+  , testE "switchHoldPromptly-4" $ do
       e <- events1
-      switchPromptly never $ (deep e <$ e)
+      switchHoldPromptly never $ (deep e <$ e)
 
   , testE "switch-5" $ do
       e <- events1
       switch <$> hold never (deep e <$ e)
 
-  , testE "switchPromptly-5" $ do
+  , testE "switchHoldPromptly-5" $ do
     e <- events1
-    switchPromptly never $ flip push e $
+    switchHoldPromptly never $ flip push e $
       const (Just <$> headE e)
 
-  , testE "switchPromptly-6" $ do
+  , testE "switchHoldPromptly-6" $ do
       e <- events1
-      switchPromptly never $ flip pushAlways e $
-        const (switchPromptly e never)
+      switchHoldPromptly never $ flip pushAlways e $
+        const (switchHoldPromptly e never)
 
   , testE "coincidence-1" $ do
       e <- events1


### PR DESCRIPTION
Create non-prompt counterparts, even though these helper functions are dramatically simpler, so that no one mistakenly thinks we are endorsing the prompt versions over their non-prompt equivalents. This is important because the "prompt" semantics are rarely needed, yet are much more difficult to use
correctly.

Also, rename `switchPromptly` and `switchPromptOnly` to `switchHold*`. This helpers show how they are far more related to each other (having identical types) than they are to plain `switch`.

One small downside of this change is that it obscures relationship between `switchPromptlyDyn` and `switchHoldDyn`. This is deemd worth it as the use of the `current` behavior to avoid holding really does make a semantic difference: Old inner events prior to the first outer event firing will never be lost.