### PR TITLE
Fix doc for "switcher"

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -363,8 +363,8 @@ instance Reflex t => Align (Event t) where
 gate :: Reflex t => Behavior t Bool -> Event t a -> Event t a
 gate = attachWithMaybe $ \allow a -> if allow then Just a else Nothing
 
--- | Create a new behavior given a starting behavior and switch to a the
---   behvior carried by the event when it fires.
+-- | Create a new behavior given a starting behavior and switch to the
+--   behavior carried by the event when it fires.
 switcher :: (Reflex t, MonadHold t m)
         => Behavior t a -> Event t (Behavior t a) -> m (Behavior t a)
 switcher b eb = pull . (sample <=< sample) <$> hold b eb


### PR DESCRIPTION
Hi,

I've just been reading through documentation and found this. This patch is just a small fix for a typo in Reflex.Class.