### PR TITLE
NotReady: Fix Spider NotReady instance head

### DIFF
--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2420,7 +2420,7 @@ instance Monad (SpiderHostFrame x) where
   {-# INLINABLE fail #-}
   fail s = SpiderHostFrame $ fail s
 
-instance NotReady x (SpiderHostFrame x) where
+instance NotReady (SpiderTimeline x) (SpiderHostFrame x) where
   notReadyUntil _ = pure ()
   notReady = pure ()
 


### PR DESCRIPTION
I didn't change the implementation, but the instance head looked incorrect.