### PR TITLE
Add convenience functions: 'ffor2' & 'ffor3'

### DIFF
--- a/Quickref.md
+++ b/Quickref.md
@@ -98,6 +98,10 @@ Since MonadHold depends on MonadSample, any [S] function also runs in [H] contex
 [ ]   <>   :: Monoid a => Behavior a ->        Behavior a -> Behavior a
 -- ... plus many more due to typeclass membership
 
+-- Combine multiple behaviors via applicative instance
+[ ]   ffor2 :: Behavior a -> Behavior b ->               (a -> b -> c)      -> Behavior c
+[ ]   ffor3 :: Behavior a -> Behavior b -> Behavior c -> (a -> b -> c -> d) -> Behavior d
+
 -- Behavior to Behavior by sampling current values
 [S]   sample :: Behavior a -> m a
 [ ]   pull   ::               m a -> Behavior a
@@ -134,6 +138,10 @@ Since MonadHold depends on MonadSample, any [S] function also runs in [H] contex
 [ ]   <*>                       ::           Dynamic (a -> b) ->        Dynamic a -> Dynamic b
 [ ]   >>=                       ::                  Dynamic a -> (a -> Dynamic b) -> Dynamic b
 [ ]   zipDynWith                :: (a -> b -> c) -> Dynamic a -> Dynamic b        -> Dynamic c
+
+-- Combine multiple dynamics via applicative instance
+[ ]   ffor2 :: Dynamic a -> Dynamic b ->              (a -> b -> c)      -> Dynamic c
+[ ]   ffor3 :: Dynamic a -> Dynamic b -> Dynamic c -> (a -> b -> c -> d) -> Dynamic d
 
 -- Efficient one-to-many fanout
 [ ]   demux   :: Ord k => Dynamic k -> Demux k

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -131,6 +131,8 @@ module Reflex.Class
   , mapMapWithAdjustWithMove
     -- * Miscellaneous convenience functions
   , ffor
+  , ffor2
+  , ffor3
     -- * Deprecated functions
   , MonadAdjust
   , appendEvents
@@ -575,6 +577,14 @@ pushAlways f = push (fmap Just . f)
 -- | Flipped version of 'fmap'.
 ffor :: Functor f => f a -> (a -> b) -> f b
 ffor = flip fmap
+
+-- | Rotated version of 'liftA2'.
+ffor2 :: Applicative f => f a -> f b -> (a -> b -> c) -> f c
+ffor2 a b f = liftA2 f a b
+
+-- | Rotated version of 'liftA3'.
+ffor3 :: Applicative f => f a -> f b -> f c -> (a -> b -> c -> d) -> f d
+ffor3 a b c f = liftA3 f a b c
 
 instance Reflex t => Applicative (Behavior t) where
   pure = constant


### PR DESCRIPTION
Intended to replace idioms like `ffor (zipDyn a b) $ \(a,b) -> (...)`.

I would've liked to add some more arities but `Control.Applicative` only exports up to 3.
We should only add higher arities for `ffor` if we also do for `liftA`.