### PR TITLE
Add `dropWhileE` and `takeDropWhileE` to compliment `takeWhileE`

### DIFF
--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -327,10 +327,10 @@ eitherDyn = fmap (fmap unpack) . factorDyn . fmap eitherToDSum
 factorDyn :: forall t m k v. (Reflex t, MonadFix m, MonadHold t m, GEq k) => Dynamic t (DSum k v) -> m (Dynamic t (DSum k (Compose (Dynamic t) v)))
 factorDyn d = do
   let inner :: forall m' a. (MonadFix m', MonadHold t m') => k a -> v a -> m' (Dynamic t (v a))
-      inner k v0 = holdDyn v0 . fmapMaybe id =<< takeWhileE isJust newVal
-        where newVal = ffor (updated d) $ \(newK :=> newV) -> case newK `geq` k of
-                Just Refl -> Just newV
-                Nothing -> Nothing
+      inner k v0 = (=<<) (holdDyn v0) $ flip takeWhileJustE (updated d) $
+        \(newK :=> newV) -> case newK `geq` k of
+          Just Refl -> Just newV
+          Nothing -> Nothing
       getInitial = do
         k0 :=> (v0 :: v a) <- sample $ current d
         i0 <- inner k0 v0


### PR DESCRIPTION
 - `takeWhileJustE`
 - `dropWhileE`
 - `takeDropWhileE`

`headE` is also added to `takeWhileE` as a performance optimization.

Issue #199 tracking being able to easily write tests for things like this.