### PR TITLE
 Fix Adjustable for EventWriterT with simultaneous replace and tell events

### DIFF
--- a/src/Reflex/EventWriter/Base.hs
+++ b/src/Reflex/EventWriter/Base.hs
@@ -154,10 +154,7 @@ runWithReplaceEventWriterTWith :: forall m t w a b. (Reflex t, MonadHold t m, Se
                                -> EventWriterT t w m (a, Event t b)
 runWithReplaceEventWriterTWith f a0 a' = do
   (result0, result') <- f (runEventWriterT a0) $ fmapCheap runEventWriterT a'
-  request <- holdDyn (snd result0) $ fmapCheap snd result'
-  -- We add these two separately to take advantage of the free merge being done later.  The coincidence case must come first so that it has precedence if both fire simultaneously.  (Really, we should probably block the 'switch' whenever 'updated' fires, but switchPromptlyDyn has the same issue.)
-  tellEvent $ coincidence $ updated request
-  tellEvent $ switch $ current request
+  tellEvent =<< switchHoldPromptOnly (snd result0) (fmapCheap snd result')
   return (fst result0, fmapCheap fst result')
 
 -- | Like 'runWithReplaceEventWriterTWith', but for 'sequenceIntMapWithAdjust'.
@@ -219,6 +216,7 @@ sequenceDMapWithAdjustEventWriterTWith base mapPatch weakenPatchWith patchNewEle
 tellEventsPromptly
   :: ( Foldable f
      , Reflex t
+     , MonadHold t m
      , EventWriter t w m
      )
   => Event t a
@@ -226,11 +224,10 @@ tellEventsPromptly
   -> Event t (f w)
   -> m ()
 tellEventsPromptly requests' patchNewElements mergedChildRequestMap = do
-  -- We add these two separately to take advantage of the free merge being done later.  The coincidence case must come first so that it has precedence if both fire simultaneously.  (Really, we should probably block the 'switch' whenever 'updated' fires, but switchPromptlyDyn has the same issue.)
-  tellEvent $ coincidence $ fmapCheap (mconcat . patchNewElements) requests' --TODO: Create a mergeIncrementalPromptly, and use that to eliminate this 'coincidence'
-  tellEvent $ fforMaybeCheap mergedChildRequestMap $ \m -> case toList m of
-    [] -> Nothing
-    h : t -> Just $ sconcat $ h :| t
+  let patch0 = fforMaybeCheap mergedChildRequestMap $ \m -> case toList m of
+                 [] -> Nothing
+                 h : t -> Just $ sconcat $ h :| t
+  tellEvent =<< switchHoldPromptOnly patch0 (fmapCheap (mconcat . patchNewElements) requests')
 
 instance PerformEvent t m => PerformEvent t (EventWriterT t w m) where
   type Performable (EventWriterT t w m) = Performable m


### PR DESCRIPTION
Previously if the widget being replaced has a `tellEvent` which fires at the same time as the resulting ('replace finished') event returned from `runWithReplace`, the moribund widget's `tellEvent` will still count, potentially even at the same time as a new widget's `tellEvent`.