### PR TITLE
Hide <> from Prelude

### DIFF
--- a/src/Reflex/Optimizer.hs
+++ b/src/Reflex/Optimizer.hs
@@ -16,6 +16,11 @@ import Control.Arrow
 import CoreMonad
 import Data.String
 import GhcPlugins
+
+#if MIN_VERSION_base(4,9,0)
+import Prelude hiding ((<>))
+#endif
+
 #endif
 
 #ifdef ghcjs_HOST_OS


### PR DESCRIPTION
Since base-4.9.0, Prelude exports `<>` and this creates an ambiguous occurrence wtih `GhcPlugins.<>`