### PR TITLE
Derive more newtype instances for ProfiledM

### DIFF
--- a/src/Reflex/Profiled.hs
+++ b/src/Reflex/Profiled.hs
@@ -11,6 +11,7 @@ module Reflex.Profiled where
 
 import Control.Lens hiding (children)
 import Control.Monad
+import Control.Monad.Exception
 import Control.Monad.Fix
 import Control.Monad.Primitive
 import Control.Monad.Reader
@@ -95,7 +96,8 @@ writeProfilingData :: FilePath -> IO ()
 writeProfilingData p = do
   writeFile p =<< formatCostCentreTree =<< getCostCentreTree
 
-newtype ProfiledM m a = ProfiledM { runProfiledM :: m a } deriving (Functor, Applicative, Monad, MonadFix)
+newtype ProfiledM m a = ProfiledM { runProfiledM :: m a }
+  deriving (Functor, Applicative, Monad, MonadFix, MonadException, MonadAsyncException)
 
 profileEvent :: Reflex t => Event t a -> Event t a
 profileEvent e = unsafePerformIO $ do

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2408,7 +2408,8 @@ runSpiderHostForTimeline :: SpiderHost x a -> SpiderTimelineEnv x -> IO a
 runSpiderHostForTimeline (SpiderHost a) = runReaderT a
 #endif
 
-newtype SpiderHostFrame x a = SpiderHostFrame { runSpiderHostFrame :: EventM x a } deriving (Functor, Applicative, MonadFix, MonadIO, MonadException, MonadAsyncException)
+newtype SpiderHostFrame x a = SpiderHostFrame { runSpiderHostFrame :: EventM x a }
+  deriving (Functor, Applicative, MonadFix, MonadIO, MonadException, MonadAsyncException)
 
 instance Monad (SpiderHostFrame x) where
   {-# INLINABLE (>>=) #-}


### PR DESCRIPTION
Put the "deriving" clause on its own line for easier diffing, so we can make sure these don't get out of sync.