### PR TITLE
Added `unzipE` as an alias for `splitE` and the corresponding `zipE`

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -53,6 +53,8 @@ module Reflex.Class
   , alignEventWithMaybe
     -- ** Breaking up 'Event's
   , splitE
+  , unzipE
+  , zipE
   , fanEither
   , fanThese
   , fanMap
@@ -676,6 +678,15 @@ takeDropWhileJustE f e = do
 -- same time with the respective values from the tuple.
 splitE :: Reflex t => Event t (a, b) -> (Event t a, Event t b)
 splitE e = (fmap fst e, fmap snd e)
+
+-- | Alias for 'splitE'
+unzipE :: Reflex t => Event t (a, b) -> (Event t a, Event t b)
+unzipE = splitE
+
+-- | Create a new 'Event' made of a pair of values supplied by two other 'Event's
+-- whenever they occur in simultaneous.
+zipE :: Reflex t => Event t a -> Event t b -> Event t (a, b)
+zipE = alignEventWithMaybe justThese
 
 -- | Print the supplied 'String' and the value of the 'Event' on each
 -- occurrence. This should /only/ be used for debugging.


### PR DESCRIPTION
`unzipE` breaks up an `Event` of tuples into a tuple of `Event`s that occur at the same time.
`zipE` creates an `Event` of a tuple of values supplied by two simultaneous `Event`s.

The reasoning for this is backed by the module `Data.Align`, which makes mention of the analogy that exists between the `align` family of functions for `These` and that one of `zip` for tuples.

Functions of the `split` family, on the other hand, and as a proposal for an eventual repurposing, could be used to signal whenever an `Event` matches a specific predicate, by taking the following signature:
```hs
split :: MonadHold t m => (a -> Bool) -> Event t a -> m (Event t (Event t a))
```
Or by making use of the `Splitter` data type