### PR TITLE
hlint updates

### DIFF
--- a/src/Reflex/FunctorMaybe.hs
+++ b/src/Reflex/FunctorMaybe.hs
@@ -30,4 +30,4 @@ instance FunctorMaybe Maybe where
 
 -- | @fmapMaybe f = catMaybes . fmap f@
 instance FunctorMaybe [] where
-  fmapMaybe f = catMaybes . fmap f
+  fmapMaybe = mapMaybe

--- a/test/hlint.hs
+++ b/test/hlint.hs
@@ -22,6 +22,8 @@ main = do
         , "--ignore=Use unless"
         , "--ignore=Reduce duplication"
         , "--cpp-define=USE_TEMPLATE_HASKELL"
+        , "--ignore=Use >>"
+        , "--ignore=Fuse foldr/map"
         ]
       recurseInto = and <$> sequence
         [ fileType ==? Directory


### PR DESCRIPTION
some tweaks for newer versions of hlint since 2.0.9
- ignore "suggest >> instead of >>= \_ ->"
- ignore "Fuse foldr/map"