### PR TITLE
Fix .travis.xml GHC versions and add ghc843

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 matrix:
   include:
   - env: COMPILER=ghc7103
+  - env: COMPILER=ghc843
   - env: COMPILER=ghc822
   - env: COMPILER=ghc802
   - env: COMPILER=ghcjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 matrix:
   include:
   - env: COMPILER=ghc7103
-  - env: COMPILER=ghc821
+  - env: COMPILER=ghc822
   - env: COMPILER=ghc802
   - env: COMPILER=ghcjs
 script:


### PR DESCRIPTION
`ghc821` has been removed from Nix's packages, which is leading to Travis CI errors. It should be replaced with `ghc822`. This seems to be documented here:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/haskell-packages.nix#L61

Also, it makes sense to me to add `ghc843` as well.