### PR TITLE
Add equivalent of testMoribunTellEvent for traverseDMapWithKeyWithAdjust

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -208,6 +208,7 @@ test-suite EventWriterT
   build-depends: base
                , containers
                , deepseq >= 1.3 && < 1.5
+               , dependent-map
                , dependent-sum
                , lens
                , mtl


### PR DESCRIPTION
This confirms that, although ca50bb4cf1e85e1c980b3ddad0e1b0c483542349 has caused #234, it fixes the original bug for `traverseDMapWithKeyWithAdjust` in addition to `runWithReplace`. (This will help ensure a fix to #234 does not cause a regression in that respect.)