### PR TITLE
outsource dynamic spider's fmap

### DIFF
--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2307,8 +2307,12 @@ newJoinDyn d =
   in Reflex.Spider.Internal.unsafeBuildDynamic readV0 v'
 
 instance HasSpiderTimeline x => Functor (Reflex.Class.Dynamic (SpiderTimeline x)) where
-  fmap f = SpiderDynamic . newMapDyn f . unSpiderDynamic
+  fmap = mapDynamicSpider
   x <$ d = R.unsafeBuildDynamic (return x) $ x <$ R.updated d
+
+mapDynamicSpider :: HasSpiderTimeline x => (a -> b) -> Reflex.Class.Dynamic (SpiderTimeline x) a -> Reflex.Class.Dynamic (SpiderTimeline x) b
+mapDynamicSpider f = SpiderDynamic . newMapDyn f . unSpiderDynamic
+{-# INLINE [1] mapDynamicSpider #-}
 
 instance HasSpiderTimeline x => Applicative (Reflex.Class.Dynamic (SpiderTimeline x)) where
   pure = SpiderDynamic . dynamicConst


### PR DESCRIPTION
Hi, in part of our codebase at work we are performing `fmap (==k)` over many dynamics. @goolord and i thought it might be beneficial to write some rewrite rules to use demux, and wanted write some RULES like

```haskell
{-# RULES "fmapEqDynBecomesDemux" forall (k :: Bool) (d :: Dynamic Spider Bool). fmapDynamicSpider (== k) d = demuxed (demux d) k #-}
```

and we were going to benchmark it, just for curiousity. you can't use fmap on the LHS of a rewrite rule because typeclass methods usually inline so aggressively that fmap will inline before your rule can fire, and so your rule will never fire. the solution is to typically implement fmap in terms of another function, so that rules can use those functions (where you must specialise the functor, of course) in their LHS. This is what that PR does, for the functor instance of Dynamic (SpiderTimeline x).

The usefulness of the above rewrite rule specifically is questionable, however its main purpose as a part of this comment was to show that users might want to include their own rules, and something like this would make it easier. There are more places where such an outsourcing could be done in reflex, but I didn't want to implement them if the content of this PR was seen as unnecessary.