### PR TITLE
Fix build for QueryT test

### DIFF
--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -1,15 +1,16 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 import Control.Lens
 import Control.Monad.Fix
 import Data.Align
-import Data.AppendMap () -- for the Align instance
 import qualified Data.AppendMap as AMap
 import Data.Functor.Misc
 import Data.Map (Map)
@@ -35,6 +36,10 @@ instance (Ord k, Query a, Eq (QueryResult a), Align (MonoidalMap k)) => Query (S
 
 newtype Selector k a = Selector { unSelector :: MonoidalMap k a }
   deriving (Show, Read, Eq, Ord, Functor)
+
+#if !(MIN_VERSION_monoidal_containers(0,4,1))
+deriving instance Ord k => Align (MonoidalMap k)
+#endif
 
 instance (Ord k, Eq a, Monoid a, Align (MonoidalMap k)) => Semigroup (Selector k a) where
   (Selector a) <> (Selector b) = Selector $ fmapMaybe id $ f a b


### PR DESCRIPTION
Newer versions than 0.4.0.0 of monoidal-containers will include an align
instance, but it is not present in hackage yet.