### PR TITLE
Fixes for haddocks

### DIFF
--- a/src/Data/FastWeakBag.hs
+++ b/src/Data/FastWeakBag.hs
@@ -42,8 +42,8 @@ import Data.IORef
 import System.Mem.Weak
 #endif
 
--- | A @FastWeakBag a@ holds a set of values of type @a@, but does not retain them -
--- that is, they can still be garbage-collected.  As long as the @a@s remain
+-- | A 'FastWeakBag' holds a set of values of type @/a/@, but does not retain them -
+-- that is, they can still be garbage-collected.  As long as the @/a/@ values remain
 -- alive, the 'FastWeakBag' will continue to refer to them.
 #ifdef GHCJS_FAST_WEAK
 newtype FastWeakBag a = FastWeakBag JSVal

--- a/src/Data/WeakBag.hs
+++ b/src/Data/WeakBag.hs
@@ -31,8 +31,8 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.IORef
 import System.Mem.Weak
 
--- | A @WeakBag a@ holds a set of values of type @a@, but does not retain them -
--- that is, they can still be garbage-collected.  As long as the @a@s remain
+-- | A 'WeakBag' holds a set of values of type @/a/@, but does not retain them -
+-- that is, they can still be garbage-collected.  As long as the @/a/@ values remain
 -- alive, the 'WeakBag' will continue to refer to them.
 data WeakBag a = WeakBag
   { _weakBag_nextId :: {-# UNPACK #-} !(IORef Int) --TODO: what if this wraps around?

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -34,10 +34,9 @@ module Reflex.Class
   , coerceDynamic
   , MonadSample (..)
   , MonadHold (..)
-    -- ** 'fan'-related types
+    -- ** 'fan' related types
   , EventSelector (..)
   , EventSelectorInt (..)
-    -- ** 'Incremental'-related types
     -- * Convenience functions
   , constDyn
   , pushAlways
@@ -201,7 +200,7 @@ import qualified Reflex.Patch.MapWithMove as PatchMapWithMove
 import Debug.Trace (trace)
 
 -- | The 'Reflex' class contains all the primitive functionality needed for
--- Functional Reactive Programming (FRP).  The @t@ type parameter indicates
+-- Functional Reactive Programming (FRP).  The @/t/@ type parameter indicates
 -- which "timeline" is in use.  Timelines are fully-independent FRP contexts,
 -- and the type of the timeline determines the FRP engine to be used.  For most
 -- purposes, the 'Reflex.Spider' implementation is recommended.
@@ -267,7 +266,7 @@ class ( MonadHold t (PushM t)
   -- | Create a new 'Dynamic'.  The given 'PullM' must always return the most
   -- recent firing of the given 'Event', if any.
   unsafeBuildDynamic :: PullM t a -> Event t a -> Dynamic t a
-  -- | Create a new 'Incremental'.  The given 'PullM''s value must always change
+  -- | Create a new 'Incremental'.  The given "PullM"'s value must always change
   -- in the same way that the accumulated application of patches would change
   -- that value.
   unsafeBuildIncremental :: Patch p => PullM t (PatchTarget p) -> Event t p -> Incremental t p
@@ -310,7 +309,7 @@ coerceDynamic :: (Reflex t, Coercible a b) => Dynamic t a -> Dynamic t b
 coerceDynamic = coerceWith $ dynamicCoercion Coercion
 
 -- | Construct a 'Dynamic' from a 'Behavior' and an 'Event'.  The 'Behavior'
--- _must_ change when and only when the 'Event' fires, such that the
+-- __must__ change when and only when the 'Event' fires, such that the
 -- 'Behavior''s value is always equal to the most recent firing of the 'Event';
 -- if this is not the case, the resulting 'Dynamic' will behave
 -- nondeterministically.
@@ -338,7 +337,7 @@ class MonadSample t m => MonadHold t m where
   -- value and will be updated whenever the given 'Event' occurs.  The update
   -- takes effect immediately after the 'Event' occurs; if the occurrence that
   -- sets the 'Behavior' (or one that is simultaneous with it) is used to sample
-  -- the 'Behavior', it will see the _old_ value of the 'Behavior', not the new
+  -- the 'Behavior', it will see the __old__ value of the 'Behavior', not the new
   -- one.
   hold :: a -> Event t a -> m (Behavior t a)
   default hold :: (m ~ f m', MonadTrans f, MonadHold t m') => a -> Event t a -> m (Behavior t a)
@@ -641,7 +640,7 @@ headTailE e = do
 -- event returns 'True'.
 --
 -- Starting at the current time, fire all the occurrences of the 'Event' for
--- which the given predicate returns 'True'.  When 'False' first is returned,
+-- which the given predicate returns 'True'.  When first 'False' is returned,
 -- do not fire, and permanently stop firing, even if 'True' values would have
 -- been encountered later.
 takeWhileE
@@ -656,7 +655,7 @@ takeWhileE f = takeWhileJustE $ \v -> guard (f v) $> v
 -- event returns 'Just b'.
 --
 -- Starting at the current time, fire all the occurrences of the 'Event' for
--- which the given predicate returns 'Just b'.  When 'Nothing' first is returned,
+-- which the given predicate returns 'Just b'.  When first 'Nothing' is returned,
 -- do not fire, and permanently stop firing, even if 'Just b' values would have
 -- been encountered later.
 takeWhileJustE
@@ -829,7 +828,7 @@ fanMap = fan . fmap mapToDMap
 
 -- | Switches to the new event whenever it receives one. Only the old event is
 -- considered the moment a new one is switched in; the output event will fire at
--- that moment if only if the old event does.
+-- that moment only if the old event does.
 --
 -- Because the simultaneous firing case is irrelevant, this function imposes
 -- laxer "timing requirements" on the overall circuit, avoiding many potential
@@ -875,13 +874,13 @@ coincidencePatchMap e = fmapCheap PatchMap $ coincidence $ ffor e $ \(PatchMap m
   Nothing -> fmapCheap (const Nothing) e
   Just ev -> leftmost [fmapCheap Just ev, fmapCheap (const Nothing) e]
 
--- | See 'coincicencePatchMap'
+-- | See 'coincidencePatchMap'
 coincidencePatchIntMap :: Reflex t => Event t (PatchIntMap (Event t v)) -> Event t (PatchIntMap v)
 coincidencePatchIntMap e = fmapCheap PatchIntMap $ coincidence $ ffor e $ \(PatchIntMap m) -> mergeIntMap $ ffor m $ \case
   Nothing -> fmapCheap (const Nothing) e
   Just ev -> leftmost [fmapCheap Just ev, fmapCheap (const Nothing) e]
 
--- | See 'coincicencePatchMap'
+-- | See 'coincidencePatchMap'
 coincidencePatchMapWithMove :: (Reflex t, Ord k) => Event t (PatchMapWithMove k (Event t v)) -> Event t (PatchMapWithMove k v)
 coincidencePatchMapWithMove e = fmapCheap unsafePatchMapWithMove $ coincidence $ ffor e $ \p -> mergeMap $ ffor (unPatchMapWithMove p) $ \ni -> case PatchMapWithMove._nodeInfo_from ni of
   PatchMapWithMove.From_Delete -> fforCheap e $ \_ ->
@@ -942,7 +941,7 @@ zipDyn = zipDynWith (,)
 
 -- | Combine two 'Dynamic's with a combining function.  The result will change
 -- whenever either (or both) input 'Dynamic' changes.
--- More efficient than liftA2.
+-- More efficient than 'liftA2'.
 zipDynWith :: Reflex t => (a -> b -> c) -> Dynamic t a -> Dynamic t b -> Dynamic t c
 zipDynWith f da db =
   let eab = align (updated da) (updated db)
@@ -973,7 +972,7 @@ instance (Reflex t, Monoid a) => Monoid (Dynamic t a) where
 
 -- | This function converts a 'DMap' whose elements are 'Dynamic's into a
 -- 'Dynamic' 'DMap'.  Its implementation is more efficient than doing the same
--- through the use of multiple uses of 'zipWithDyn' or 'Applicative' operators.
+-- through the use of multiple uses of 'zipDynWith' or 'Applicative' operators.
 distributeDMapOverDynPure :: forall t k. (Reflex t, GCompare k) => DMap k (Dynamic t) -> Dynamic t (DMap k Identity)
 distributeDMapOverDynPure dm = case DMap.toList dm of
   [] -> constDyn DMap.empty

--- a/src/Reflex/Collection.hs
+++ b/src/Reflex/Collection.hs
@@ -139,10 +139,10 @@ listWithKeyShallowDiff initialVals valsChanged mkChild = do
 --TODO: Something better than Dynamic t (Map k v) - we want something
 --where the Events carry diffs, not the whole value
 -- | Create a dynamically-changing set of Event-valued widgets.  This
---   is like listWithKey, specialized for widgets returning (Event t
---   a).  listWithKey would return 'Dynamic t (Map k (Event t a))' in
---   this scenario, but listViewWithKey flattens this to 'Event t (Map
---   k a)' via 'switch'.
+--   is like 'listWithKey', specialized for widgets returning @/Event t a/@.
+--   'listWithKey' would return @/Dynamic t (Map k (Event t a))/@ in
+--   this scenario, but 'listViewWithKey' flattens this to
+--   @/Event t (Map k a)/@ via 'switch'.
 listViewWithKey
   :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m)
   => Dynamic t (Map k v)

--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -265,9 +265,9 @@ traceDynWith f d =
 -- | Replace the value of the 'Event' with the current value of the 'Dynamic'
 -- each time the 'Event' occurs.
 --
--- Note: @/tagPromptlyDyn d e@/ differs from @/tag (current d) e/@ in the case that @/e/@ is firing
--- at the same time that @/d/@ is changing.  With @/tagPromptlyDyn d e/@, the __new__ value of @/d@/
--- will replace the value of @/e/@, whereas with @/tag (current d) e@/, the __old__ value
+-- Note: @/tagPromptlyDyn d e/@ differs from @/tag (current d) e/@ in the case that @/e/@ is firing
+-- at the same time that @/d/@ is changing.  With @/tagPromptlyDyn d e/@, the __new__ value of @/d/@
+-- will replace the value of @/e/@, whereas with @/tag (current d) e/@, the __old__ value
 -- will be used, since the 'Behavior' won't be updated until the end of the frame.
 -- Additionally, this means that the output 'Event' may not be used to directly change
 -- the input 'Dynamic', because that would mean its value depends on itself.  __When creating__
@@ -293,8 +293,7 @@ attachPromptlyDynWith f = attachPromptlyDynWithMaybe $ \a b -> Just $ f a b
 -- current value of the 'Dynamic' value and possibly filtering if the combining
 -- function returns 'Nothing'.
 --
--- Note: `attachPromptlyDynWithMaybe f d` is not the same as `attachWithMaybe f
--- (current d)`.  See 'tagPromptlyDyn' for details.
+-- Note: @/attachPromptlyDynWithMaybe f d/@ is not the same as @/attachWithMaybe f (current d)/@.  See 'tagPromptlyDyn' for details.
 attachPromptlyDynWithMaybe :: Reflex t => (a -> b -> Maybe c) -> Dynamic t a -> Event t b -> Event t c
 attachPromptlyDynWithMaybe f d e =
   let e' = attach (current d) e

--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -58,6 +58,7 @@ module Reflex.Dynamic
   , Demux
   , demux
   , demuxed
+    -- * Miscellaneous
     -- Things that probably aren't very useful:
   , HList (..)
   , FHList (..)
@@ -67,7 +68,7 @@ module Reflex.Dynamic
   , AllAreFunctors (..)
   , HListPtr (..)
   , distributeFHListOverDynPure
-    -- Unsafe
+    -- * Unsafe
   , unsafeDynamic
     -- * Deprecated functions
   , apDyn
@@ -130,7 +131,7 @@ holdUniqDyn = holdUniqDynBy (==)
 holdUniqDynBy :: (Reflex t, MonadHold t m, MonadFix m) => (a -> a -> Bool) -> Dynamic t a -> m (Dynamic t a)
 holdUniqDynBy eq = scanDynMaybe id (\new old -> if new `eq` old then Nothing else Just new)
 
--- | Dynamic Maybe that can only update from Nothing to Just or Just to Just (i.e., cannot revert to Nothing)
+-- | @/Dynamic Maybe/@ that can only update from @/Nothing/@ to @/Just/@ or @/Just/@ to @/Just/@ (i.e., cannot revert to @/Nothing/@)
 improvingMaybe :: (Reflex t, MonadHold t m, MonadFix m) => Dynamic t (Maybe a) -> m (Dynamic t (Maybe a))
 improvingMaybe = scanDynMaybe id (\new _ -> if isJust new then Just new else Nothing)
 
@@ -195,9 +196,9 @@ switchDyn :: forall t a. Reflex t => Dynamic t (Event t a) -> Event t a
 switchDyn d = switch (current d)
 
 -- | Switches to the new 'Event' whenever it receives one.  Switching occurs
--- *before* the inner 'Event' fires - so if the 'Dynamic' changes and both the
+-- __before__ the inner 'Event' fires - so if the 'Dynamic' changes and both the
 -- old and new inner Events fire simultaneously, the output will fire with the
--- value of the *new* 'Event'.
+-- value of the __new__ 'Event'.
 --
 -- Prefer 'switchDyn' to this where possible. The timing requirements that
 -- switching before imposes are likely to bring down your app unless you are
@@ -238,7 +239,7 @@ joinDynThroughMap :: forall t k a. (Reflex t, Ord k) => Dynamic t (Map k (Dynami
 joinDynThroughMap = joinDyn . fmap distributeMapOverDynPure
 
 -- | Print the value of the 'Dynamic' when it is first read and on each
--- subsequent change that is observed (as traceEvent), prefixed with the
+-- subsequent change that is observed (as 'traceEvent'), prefixed with the
 -- provided string. This should /only/ be used for debugging.
 --
 -- Note: Just like Debug.Trace.trace, the value will only be shown if something
@@ -248,7 +249,7 @@ traceDyn s = traceDynWith $ \x -> s <> ": " <> show x
 
 -- | Print the result of applying the provided function to the value
 -- of the 'Dynamic' when it is first read and on each subsequent change
--- that is observed (as traceEvent). This should /only/ be used for
+-- that is observed (as 'traceEvent'). This should /only/ be used for
 -- debugging.
 --
 -- Note: Just like Debug.Trace.trace, the value will only be shown if something
@@ -264,27 +265,27 @@ traceDynWith f d =
 -- | Replace the value of the 'Event' with the current value of the 'Dynamic'
 -- each time the 'Event' occurs.
 --
--- Note: `tagPromptlyDyn d e` differs from `tag (current d) e` in the case that `e` is firing
--- at the same time that `d` is changing.  With `tagPromptlyDyn d e`, the *new* value of `d`
--- will replace the value of `e`, whereas with `tag (current d) e`, the *old* value
+-- Note: @/tagPromptlyDyn d e@/ differs from @/tag (current d) e/@ in the case that @/e/@ is firing
+-- at the same time that @/d/@ is changing.  With @/tagPromptlyDyn d e/@, the __new__ value of @/d@/
+-- will replace the value of @/e/@, whereas with @/tag (current d) e@/, the __old__ value
 -- will be used, since the 'Behavior' won't be updated until the end of the frame.
 -- Additionally, this means that the output 'Event' may not be used to directly change
--- the input 'Dynamic', because that would mean its value depends on itself.  When creating
--- cyclic data flows, generally `tag (current d) e` is preferred.
+-- the input 'Dynamic', because that would mean its value depends on itself.  __When creating__
+-- __cyclic data flows, generally @/tag (current d) e/@ is preferred.__
 tagPromptlyDyn :: Reflex t => Dynamic t a -> Event t b -> Event t a
 tagPromptlyDyn = attachPromptlyDynWith const
 
 -- | Attach the current value of the 'Dynamic' to the value of the
 -- 'Event' each time it occurs.
 --
--- Note: `attachPromptlyDyn d` is not the same as `attach (current d)`.  See 'tagPromptlyDyn' for details.
+-- Note: @/attachPromptlyDyn d/@ is not the same as @/attach (current d)/@.  See 'tagPromptlyDyn' for details.
 attachPromptlyDyn :: Reflex t => Dynamic t a -> Event t b -> Event t (a, b)
 attachPromptlyDyn = attachPromptlyDynWith (,)
 
 -- | Combine the current value of the 'Dynamic' with the value of the
 -- 'Event' each time it occurs.
 --
--- Note: `attachPromptlyDynWith f d` is not the same as `attachWith f (current d)`.  See 'tagPromptlyDyn' for details.
+-- Note: @/attachPromptlyDynWith f d/@ is not the same as @/attachWith f (current d)/@.  See 'tagPromptlyDyn' for details.
 attachPromptlyDynWith :: Reflex t => (a -> b -> c) -> Dynamic t a -> Event t b -> Event t c
 attachPromptlyDynWith f = attachPromptlyDynWithMaybe $ \a b -> Just $ f a b
 
@@ -302,8 +303,8 @@ attachPromptlyDynWithMaybe f d e =
        These (_, b) a -> f a b -- Both events are firing, so use the newer value
        That _ -> Nothing -- The tagging event isn't firing, so don't fire
 
--- | Factor a @Dynamic t (Maybe a)@ into a @Dynamic t (Maybe (Dynamic t a))@,
--- such that the outer 'Dynamic' is updated only when the 'Maybe''s constructor
+-- | Factor a @/Dynamic t (Maybe a)/@ into a @/Dynamic t (Maybe (Dynamic t a))/@,
+-- such that the outer 'Dynamic' is updated only when the "Maybe"'s constructor
 -- chages from 'Nothing' to 'Just' or vice-versa.  Whenever the constructor
 -- becomes 'Just', an inner 'Dynamic' will be provided, whose value will track
 -- the 'a' inside the 'Just'; when the constructor becomes 'Nothing', the

--- a/src/Reflex/Pure.hs
+++ b/src/Reflex/Pure.hs
@@ -43,12 +43,12 @@ import Data.Type.Coercion
 import Reflex.Class
 
 -- | A completely pure-functional 'Reflex' timeline, identifying moments in time
--- with the type @t@.
+-- with the type @/t/@.
 data Pure t
 
--- | The Enum instance of t must be dense: for all x :: t, there must not exist
--- any y :: t such that pred x < y < x. The HasTrie instance will be used
--- exclusively to memoize functions of t, not for any of its other capabilities.
+-- | The 'Enum' instance of @/t/@ must be dense: for all @/x :: t/@, there must not exist
+-- any @/y :: t/@ such that @/'pred' x < y < x/@. The 'HasTrie' instance will be used
+-- exclusively to memoize functions of @/t/@, not for any of its other capabilities.
 instance (Enum t, HasTrie t, Ord t) => Reflex (Pure t) where
 
   newtype Behavior (Pure t) a = Behavior { unBehavior :: t -> a }


### PR DESCRIPTION
In the inlined code like `Dynamic t (Map k a)`, I have made it italic/emphasis. This is a bit unconventional, but increases the readability.
Its a surprise that haddock doesn"t allow inline code with backticks. The only thing it supports is monospaced text (inside @), but this appears almost similar to the plain text. 
