### PR TITLE
Tighten base lower bound

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -37,7 +37,7 @@ library
   hs-source-dirs: src
   build-depends:
     MemoTrie == 0.6.*,
-    base >= 4.7 && < 4.13,
+    base >= 4.9 && < 4.13,
     bifunctors >= 5.2 && < 5.6,
     comonad,
     containers >= 0.5 && < 0.7,


### PR DESCRIPTION
Reflex does not build with GHC 7.10 or below.