### PR TITLE
Relax bounds on 'these', add explicit import to avoid clash

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -60,7 +60,7 @@ library
     semigroups >= 0.16 && < 0.19,
     stm >= 2.4 && < 2.6,
     syb >= 0.5 && < 0.8,
-    these >= 0.4 && < 0.7.6,
+    these >= 0.4 && < 0.7.7,
     time >= 1.4 && < 1.9,
     transformers >= 0.2,
     transformers-compat >= 0.3,

--- a/src/Reflex/Patch/MapWithMove.hs
+++ b/src/Reflex/Patch/MapWithMove.hs
@@ -22,7 +22,7 @@ import qualified Data.Map as Map
 import Data.Maybe
 import Data.Semigroup (Semigroup (..), (<>))
 import qualified Data.Set as Set
-import Data.These
+import Data.These (These(..))
 import Data.Tuple
 
 -- | Patch a DMap with additions, deletions, and moves.  Invariant: If key @k1@


### PR DESCRIPTION
Fixes #270.

This passes `cabal new-test`, but has not been tested against ghcjs. I do not know how to update reflex-platform either, but this seems like a pretty safe change.
