### PR TITLE
Deprecate FunctorMaybe in favor of Filterable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 , template-haskell , these, time, transformers
 , transformers-compat, unbounded-delays, prim-uniq
 , data-default, filepath, directory, filemanip, ghcjs-base
-, monoidal-containers
+, monoidal-containers, witherable
 , useTemplateHaskell ? true
 }:
 mkDerivation {
@@ -21,7 +21,7 @@ mkDerivation {
     transformers-compat prim-uniq
     base bifunctors containers deepseq dependent-map dependent-sum
     mtl ref-tf split transformers data-default
-    random time unbounded-delays monoidal-containers
+    random time unbounded-delays monoidal-containers witherable
   ] ++ (if ghc.isGhcjs or false then [
     ghcjs-base
   ] else []) ++ (if !useTemplateHaskell then [] else [

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -1,5 +1,5 @@
 Name: reflex
-Version: 0.5.0.1
+Version: 0.6
 Synopsis: Higher-order Functional Reactive Programming
 Description: Reflex is a high-performance, deterministic, higher-order Functional Reactive Programming system
 License: BSD3

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -64,7 +64,8 @@ library
     time >= 1.4 && < 1.9,
     transformers >= 0.2,
     transformers-compat >= 0.3,
-    unbounded-delays >= 0.1.0.0 && < 0.2
+    unbounded-delays >= 0.1.0.0 && < 0.2,
+    witherable >= 0.2 && < 0.4
 
   exposed-modules:
     Data.AppendMap,

--- a/src/Data/AppendMap.hs
+++ b/src/Data/AppendMap.hs
@@ -31,9 +31,10 @@ import qualified Data.Map.Internal.Debug as Map (showTree, showTreeWith)
 #else
 import qualified Data.Map as Map (showTree, showTreeWith)
 #endif
-import Data.Map.Monoidal
-import Reflex.Class (FunctorMaybe (..))
 import Reflex.Patch (Additive, Group (..))
+import Data.Map.Monoidal hiding (mapMaybe)
+import qualified Data.Map.Monoidal as M
+import Data.Witherable (Filterable(..))
 
 {-# DEPRECATED AppendMap "Use 'MonoidalMap' instead" #-}
 type AppendMap = MonoidalMap
@@ -45,8 +46,8 @@ _unAppendMap = getMonoidalMap
 pattern AppendMap :: Map k v -> MonoidalMap k v
 pattern AppendMap m = MonoidalMap m
 
-instance FunctorMaybe (MonoidalMap k) where
-  fmapMaybe = mapMaybe
+instance Filterable (MonoidalMap k) where
+  mapMaybe = M.mapMaybe
 
 -- | Deletes a key, returning 'Nothing' if the result is empty.
 nonEmptyDelete :: Ord k => k -> MonoidalMap k a -> Maybe (MonoidalMap k a)
@@ -60,7 +61,7 @@ mapMaybeNoNull :: (a -> Maybe b)
                -> MonoidalMap token a
                -> Maybe (MonoidalMap token b)
 mapMaybeNoNull f as =
-  let bs = fmapMaybe f as
+  let bs = mapMaybe f as
   in if null bs
        then Nothing
        else Just bs

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -139,6 +139,7 @@ module Reflex.Class
   , unsafeMapIncremental
     -- * 'Filterable' convenience functions
   , FunctorMaybe -- fmapMaybe is purposely not exported from deprecated 'FunctorMaybe' and the new alias is exported instead
+  , mapMaybe -- Re-exported for convenience
   , fmapMaybe
   , fforMaybe
   , ffilter

--- a/src/Reflex/FunctorMaybe.hs
+++ b/src/Reflex/FunctorMaybe.hs
@@ -9,46 +9,33 @@ module Reflex.FunctorMaybe
   ) where
 
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
 import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Maybe
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Option(..))
 #endif
+import Data.Witherable
 
 --TODO: See if there's a better class in the standard libraries already
 
 -- | A class for values that combines filtering and mapping using 'Maybe'.
--- Morally, @'FunctorMaybe' ~ KleisliFunctor 'Maybe'@. Also similar is the
--- @Witherable@ typeclass, but it requires @'Foldable' f@ and @'Traversable' f@,
--- and e.g. 'Event' is instance of neither.
---
--- A definition of 'fmapMaybe' must satisfy the following laws:
---
--- [/identity/]
---   @'fmapMaybe' 'Just' ≡ 'id'@
---
--- [/composition/]
---   @'fmapMaybe' (f <=< g) ≡ 'fmapMaybe' f . 'fmapMaybe' g@
+-- Morally, @'FunctorMaybe' ~ KleisliFunctor 'Maybe'@.
+{-# DEPRECATED FunctorMaybe "Use 'Filterable' from Data.Witherable instead" #-}
 class FunctorMaybe f where
   -- | Combined mapping and filtering function.
   fmapMaybe :: (a -> Maybe b) -> f a -> f b
 
--- | @fmapMaybe = (=<<)
 instance FunctorMaybe Maybe where
-  fmapMaybe = (=<<)
+  fmapMaybe = mapMaybe
 
 #if MIN_VERSION_base(4,9,0)
 deriving instance FunctorMaybe Option
 #endif
 
--- | @fmapMaybe = mapMaybe@
 instance FunctorMaybe [] where
   fmapMaybe = mapMaybe
 
 instance FunctorMaybe (Map k) where
-  fmapMaybe = Map.mapMaybe
+  fmapMaybe = mapMaybe
 
 instance FunctorMaybe IntMap where
-  fmapMaybe = IntMap.mapMaybe
+  fmapMaybe = mapMaybe

--- a/src/Reflex/Requester/Base.hs
+++ b/src/Reflex/Requester/Base.hs
@@ -378,7 +378,7 @@ traverseIntMapWithKeyWithAdjustRequesterTWith base patchNewElements mergePatchIn
           pack = Entry
           f' :: IntMap.Key -> (Int, v) -> m (Event t (IntMap (RequesterData request)), v')
           f' k (n, v) = do
-            (result, myRequests) <- runRequesterT (f k v) $ fmapMaybeCheap (IntMap.lookup n) $ selectInt responses k --TODO: Instead of doing fmapMaybeCheap, can we share a fanInt across all instances of a given key, or at least the ones that are adjacent in time?
+            (result, myRequests) <- runRequesterT (f k v) $ mapMaybeCheap (IntMap.lookup n) $ selectInt responses k --TODO: Instead of doing mapMaybeCheap, can we share a fanInt across all instances of a given key, or at least the ones that are adjacent in time?
             return (fmapCheap (IntMap.singleton n) myRequests, result)
       ndm' <- numberOccurrencesFrom 1 dm'
       (children0, children') <- base f' (fmap ((,) 0) dm0) $ fmap (\(n, dm) -> fmap ((,) n) dm) ndm' --TODO: Avoid this somehow, probably by adding some sort of per-cohort information passing to Adjustable
@@ -426,7 +426,7 @@ traverseDMapWithKeyWithAdjustRequesterTWith base mapPatch weakenPatchWith patchN
           pack = Entry
           f' :: forall a. k a -> Compose ((,) Int) v a -> m (Compose ((,) (Event t (IntMap (RequesterData request)))) v' a)
           f' k (Compose (n, v)) = do
-            (result, myRequests) <- runRequesterT (f k v) $ fmapMaybeCheap (IntMap.lookup n) $ select responses (Const2 (Some.This k))
+            (result, myRequests) <- runRequesterT (f k v) $ mapMaybeCheap (IntMap.lookup n) $ select responses (Const2 (Some.This k))
             return $ Compose (fmapCheap (IntMap.singleton n) myRequests, result)
       ndm' <- numberOccurrencesFrom 1 dm'
       (children0, children') <- base f' (DMap.map (\v -> Compose (0, v)) dm0) $ fmap (\(n, dm) -> mapPatch (\v -> Compose (n, v)) dm) ndm'

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -49,16 +49,16 @@ import Data.GADT.Compare
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IORef
-import Data.Maybe
+import Data.Maybe hiding (mapMaybe)
 import Data.Monoid ((<>))
 import Data.Proxy
 import Data.These
 import Data.Traversable
+import Data.Witherable (Filterable, mapMaybe)
 import GHC.Exts
 import GHC.IORef (IORef (..))
 import GHC.Stack
 import Reflex.FastWeak
-import Reflex.FunctorMaybe
 import System.IO.Unsafe
 import System.Mem.Weak
 import Unsafe.Coerce
@@ -1128,12 +1128,12 @@ newInvalidatorSwitch subd = return $! InvalidatorSwitch subd
 newInvalidatorPull :: Pull x a -> IO (Invalidator x)
 newInvalidatorPull p = return $! InvalidatorPull p
 
-instance HasSpiderTimeline x => FunctorMaybe (Event x) where
-  fmapMaybe f = push $ return . f
+instance HasSpiderTimeline x => Filterable (Event x) where
+  mapMaybe f = push $ return . f
 
 instance HasSpiderTimeline x => Align (Event x) where
   nil = eventNever
-  align ea eb = fmapMaybe dmapToThese $ merge $ dynamicConst $ DMap.fromDistinctAscList [LeftTag :=> ea, RightTag :=> eb]
+  align ea eb = mapMaybe dmapToThese $ merge $ dynamicConst $ DMap.fromDistinctAscList [LeftTag :=> ea, RightTag :=> eb]
 
 data DynType x p = UnsafeDyn !(BehaviorM x (PatchTarget p), Event x p)
                  | BuildDyn  !(EventM x (PatchTarget p), Event x p)

--- a/src/Reflex/Time.hs
+++ b/src/Reflex/Time.hs
@@ -28,7 +28,7 @@ import Control.Monad.IO.Class
 import Data.Align
 import Data.Data (Data)
 import Data.Fixed
-import Data.Semigroup
+import Data.Semigroup ((<>))
 import Data.Sequence (Seq, (|>))
 import qualified Data.Sequence as Seq
 import Data.These


### PR DESCRIPTION
Deprecates FunctorMaybe.

The class is still re-exported by Reflex.Class and hence by Reflex, but the method fmapMaybe is not automatically re-exported (in favor of exporting a new fmapMaybe alias to mapMaybe from Filterable). This isn't ideal, as it'll still cause some breakage where instances were defined (I think).