### PR TITLE
Use reverse chronological order in ChangeLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for reflex
 
+## 0.6.1.0
+
+* Re-export all of `Data.Map.Monoidal`
+* Fix `QueryT` and `RequesterT` tests
+
 ## 0.6.0.0 -- 2019-03-20
 
 * Deprecate `FunctorMaybe` in favor of `Data.Witherable.Filterable`. We still export `fmapMaybe`, `ffilter`, etc., but they all rely on `Filterable` now.
@@ -10,8 +15,3 @@
 * Add `withRequesterT` to map functions over the request and response of a `RequesterT`.
 * Suppress nil patches in `QueryT` as an optimization. The `Query` type must now have an `Eq` instance.
 * Add `throttleBatchWithLag` to `Reflex.Time`. See that module for details.
-
-## 0.6.1.0
-
-* Re-export all of `Data.Map.Monoidal`
-* Fix `QueryT` and `RequesterT` tests


### PR DESCRIPTION
A preference of mine so that I see the most recent changes first when I open the file in GitHub, etc. When in a termal, I'd use `less` anyway. Feel free to close if you disagree.