### PR TITLE
WIP: Add common instances for 'Workflow'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix `holdDyn` so that it is lazy in its event argument
+* Relax constraint from `Applicative` to `Apply` in `ffor2` & `ffor3`. `Event`s and `Map`s can now use these utils.
 
 ## 0.6.1.0
 

--- a/Quickref.md
+++ b/Quickref.md
@@ -59,6 +59,9 @@ Since MonadHold depends on MonadSample, any [S] function also runs in [H] contex
 [ ]   mergeList  :: [Event a] -> Event (NonEmpty a)
 [ ]   merge      :: GCompare k => DMap k Event -> Event (DMap k Identity)
 [ ]   mergeMap   :: Ord k => Map k (Event a) -> Event (Map k a)
+[ ]   ffor2      :: Event a -> Event b ->            (a -> b -> c)      -> Event c
+[ ]   ffor3      :: Event a -> Event b -> Event c -> (a -> b -> c -> d) -> Event d
+
 
 -- Efficient one-to-many fanout
 [ ]   fanMap    :: Ord k      => Event (Map k a)         -> EventSelector (Const2 k a)
@@ -98,7 +101,7 @@ Since MonadHold depends on MonadSample, any [S] function also runs in [H] contex
 [ ]   <>   :: Monoid a => Behavior a ->        Behavior a -> Behavior a
 -- ... plus many more due to typeclass membership
 
--- Combine multiple behaviors via applicative instance
+-- Combine multiple behaviors via 'Data.Functor.Plus.Apply' instance
 [ ]   ffor2 :: Behavior a -> Behavior b ->               (a -> b -> c)      -> Behavior c
 [ ]   ffor3 :: Behavior a -> Behavior b -> Behavior c -> (a -> b -> c -> d) -> Behavior d
 
@@ -139,7 +142,7 @@ Since MonadHold depends on MonadSample, any [S] function also runs in [H] contex
 [ ]   >>=                       ::                  Dynamic a -> (a -> Dynamic b) -> Dynamic b
 [ ]   zipDynWith                :: (a -> b -> c) -> Dynamic a -> Dynamic b        -> Dynamic c
 
--- Combine multiple dynamics via applicative instance
+-- Combine multiple dynamics via 'Data.Functor.Plus.Apply' instance
 [ ]   ffor2 :: Dynamic a -> Dynamic b ->              (a -> b -> c)      -> Dynamic c
 [ ]   ffor3 :: Dynamic a -> Dynamic b -> Dynamic c -> (a -> b -> c -> d) -> Dynamic d
 

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -568,12 +568,12 @@ ffor :: Functor f => f a -> (a -> b) -> f b
 ffor = flip fmap
 
 -- | Rotated version of 'liftA2'.
-ffor2 :: Applicative f => f a -> f b -> (a -> b -> c) -> f c
-ffor2 a b f = liftA2 f a b
+ffor2 :: Apply f => f a -> f b -> (a -> b -> c) -> f c
+ffor2 a b f = liftF2 f a b
 
 -- | Rotated version of 'liftA3'.
-ffor3 :: Applicative f => f a -> f b -> f c -> (a -> b -> c -> d) -> f d
-ffor3 a b c f = liftA3 f a b c
+ffor3 :: Apply f => f a -> f b -> f c -> (a -> b -> c -> d) -> f d
+ffor3 a b c f = liftF3 f a b c
 
 instance Reflex t => Applicative (Behavior t) where
   pure = constant

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- |
@@ -6,17 +9,24 @@
 -- Description:
 --   Provides a convenient way to describe a series of interrelated widgets that
 --   can send data to, invoke, and replace one another. Useful for modeling user interface
---   "workflows."
+--   "workflows".
 module Reflex.Workflow (
     Workflow (..)
   , workflow
   , workflowView
   , mapWorkflow
   , mapWorkflowCheap
+  , parallelWorkflows
+  , zipWorkflows
   ) where
 
-import Control.Arrow ((***))
+import Control.Arrow (first, (***))
 import Control.Monad.Fix (MonadFix)
+
+import Data.Align
+import Data.These
+import Data.Functor.Bind
+import Data.Functor.Plus
 
 import Reflex.Class
 import Reflex.Adjustable.Class
@@ -26,7 +36,48 @@ import Reflex.PostBuild.Class
 
 -- | A widget in a workflow
 -- When the 'Event' returned by a 'Workflow' fires, the current 'Workflow' is replaced by the one inside the firing 'Event'. A series of 'Workflow's must share the same return type.
-newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) }
+newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) } deriving Functor
+
+instance (Apply m, Reflex t) => Apply (Workflow t m) where
+  liftF2 f = parallelWorkflows f f f
+
+instance (Apply m, Applicative m, Reflex t) => Applicative (Workflow t m) where
+  pure a = Workflow $ pure (a, never)
+  (<*>) = (<.>)
+
+instance (Apply m, Reflex t, Semigroup a) => Semigroup (Workflow t m a) where
+  (<>) = liftF2 (<>)
+
+instance (Apply m, Applicative m, Reflex t, Monoid a) => Monoid (Workflow t m a) where
+  mempty = pure mempty
+
+instance (Apply m, Reflex t) => Alt (Workflow t m) where
+  (<!>) = parallelWorkflows const (flip const) const
+
+zipWorkflows :: (Apply m, Reflex t) => Workflow t m a -> Workflow t m b -> Workflow t m (a,b)
+zipWorkflows = parallelWorkflows (,) (,) (,)
+
+parallelWorkflows :: (Apply m, Reflex t)
+                  => (a -> b -> c) -> (a -> b -> c) -> (a -> b -> c)
+                  -> Workflow t m a -> Workflow t m b -> Workflow t m c
+parallelWorkflows fL fR fLR = go fLR
+  where
+    go f0 wl wr = Workflow $ ffor2 (unWorkflow wl) (unWorkflow wr) $ \(l0, wlEv) (r0, wrEv) ->
+      (f0 l0 r0, ffor (align wlEv wrEv) $ \case
+          This wl' -> go fL wl' wr
+          That wr' -> go fR wl wr'
+          These wl' wr' -> go fLR wl' wr'
+      )
+
+instance (Apply m, Monad m, Reflex t) => Bind (Workflow t m) where
+  join wwa = Workflow $ do
+    let replaceInitial a wa = Workflow $ first (const a) <$> unWorkflow wa
+    (wa0, wwaEv) <- unWorkflow wwa
+    (a0, waEv) <- unWorkflow wa0
+    pure (a0, join <$> leftmost [wwaEv, flip replaceInitial wwa <$> waEv])
+
+instance (Apply m, Monad m, Reflex t) => Monad (Workflow t m) where
+  (>>=) = (>>-)
 
 -- | Runs a 'Workflow' and returns the 'Dynamic' result of the 'Workflow' (i.e., a 'Dynamic' of the value produced by the current 'Workflow' node, and whose update 'Event' fires whenever one 'Workflow' is replaced by another).
 workflow :: forall t m a. (Reflex t, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
@@ -41,9 +92,10 @@ workflowView w0 = do
       eReplace <- fmap switch $ hold never $ fmap snd eResult
   return $ fmap fst eResult
 
--- | Map a function over a 'Workflow', possibly changing the resturn type.
+{-# DEPRECATED mapWorkflow "Use 'fmap' instead" #-}
+-- | Map a function over a 'Workflow', possibly changing the return type.
 mapWorkflow :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
-mapWorkflow f (Workflow x) = Workflow (fmap (f *** fmap (mapWorkflow f)) x)
+mapWorkflow = fmap
 
 -- | Map a "cheap" function over a 'Workflow'. Refer to the documentation for 'pushCheap' for more information and performance considerations.
 mapWorkflowCheap :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -110,12 +110,13 @@ zipNEListWithWorkflow (k :| ks) w = Workflow $ ffor (unWorkflow w) $ \(a0, wEv) 
       Just nel -> zipNEListWithWorkflow nel <$> wEv)
 
 
-chainWorkflows :: (Apply m, Reflex t)
-                  => (These () () -> (a,b) -> c) -- ^ Payload combining function based on ocurring workflow
-                  -> (forall x y. (m x, m y) -> m (x,y)) -- ^ Widget combining function
-                  -> Workflow t m a
-                  -> Workflow t m b
-                  -> Workflow t m c
+chainWorkflows
+  :: (Apply m, Reflex t)
+  => (These () () -> (a,b) -> c) -- ^ Payload combining function based on ocurring workflow
+  -> (forall x y. (m x, m y) -> m (x,y)) -- ^ Widget combining function
+  -> Workflow t m a
+  -> Workflow t m b
+  -> Workflow t m c
 chainWorkflows combineP combineW wl0 wr0 = go (These () ()) wl0 wr0
   where
     go occurring wl wr = Workflow $ ffor (combineW (unWorkflow wl, unWorkflow wr)) $ \((l0, wlEv), (r0, wrEv)) ->
@@ -135,12 +136,13 @@ zipWorkflowsWith f = parallelWorkflows (ignoreTimings f') zipWidgets
   where f' = uncurry f
 
 -- | Combine two independent workflows. The output workflow is replaced when either input is replaced
-parallelWorkflows :: (Functor m, Reflex t)
-                  => (These () () -> (a,b) -> c) -- ^ Payload combining function based on ocurring workflow
-                  -> (forall x y. (m x, m y) -> m (x,y)) -- ^ Widget combining function
-                  -> Workflow t m a
-                  -> Workflow t m b
-                  -> Workflow t m c
+parallelWorkflows
+  :: (Functor m, Reflex t)
+  => (These () () -> (a,b) -> c) -- ^ Payload combining function based on ocurring workflow
+  -> (forall x y. (m x, m y) -> m (x,y)) -- ^ Widget combining function
+  -> Workflow t m a
+  -> Workflow t m b
+  -> Workflow t m c
 parallelWorkflows combineP combineW = go (These () ())
   where
     go occurring wl wr = Workflow $ ffor (combineW (unWorkflow wl, unWorkflow wr)) $ \((l0, wlEv), (r0, wrEv)) ->

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -32,13 +32,17 @@ import Control.Monad.Fix (MonadFix)
 import Control.Lens (FunctorWithIndex(..), set, (&), (.~))
 
 import Data.Align
+#if MIN_VERSION_these(0, 8, 0)
 import Data.Align.Indexed (AlignWithIndex)
-import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
+#endif
+import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
 import Data.Functor.Bind
 import Data.Functor.Plus
-import Data.These hiding (swap)
+import Data.These (These(..), fromThese)
 #if MIN_VERSION_these(0, 8, 0)
 import Data.These.Lens (here, there)
+#else
+import Data.These (here, there)
 #endif
 import Data.Tuple (swap)
 

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -43,7 +43,7 @@ import Reflex.PostBuild.Class
 -- When the 'Event' returned by a 'Workflow' fires, the current 'Workflow' is replaced by the one inside the firing 'Event'. A series of 'Workflow's must share the same return type.
 newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) } deriving Functor
 
--- | Creates a workflow that's replaced when either input workflow is replaced.
+-- | Create a workflow that's replaced when either input workflow is replaced.
 -- The value of the output workflow is obtained by applying the provided function to the values of the input workflows
 instance (Apply m, Reflex t) => Apply (Workflow t m) where
   liftF2 f = parallelWorkflows f' f' f'
@@ -60,7 +60,7 @@ instance (Apply m, Applicative m, Reflex t, Monoid a) => Monoid (Workflow t m a)
   mempty = pure mempty
 
 -- | Creates a workflow that's replaced when either input workflow is replaced.
--- The value of the output workflow is taken from the most-recently replaced input workflow.
+-- The value of the output workflow is taken from the most-recently replaced input workflow (leftmost wins when simultaneous).
 instance (Apply m, Reflex t) => Alt (Workflow t m) where
   (<!>) = parallelWorkflows fst snd fst
 
@@ -72,7 +72,7 @@ instance (Apply m, Reflex t) => Semialign (Workflow t m) where
 zipWorkflows :: (Apply m, Reflex t) => Workflow t m a -> Workflow t m b -> Workflow t m (a,b)
 zipWorkflows = parallelWorkflows id id id
 
--- | Combines two independent workflows. The output workflow is replaced when either input is replaced
+-- | Combine two independent workflows. The output workflow is replaced when either input is replaced
 parallelWorkflows :: (Apply m, Reflex t)
                   => ((a,b) -> c) -- ^ Combining function when left workflow is replaced
                   -> ((a,b) -> c) -- ^ Combining function when right workflow is replaced
@@ -89,7 +89,7 @@ parallelWorkflows fL fR fLR = go fLR
           These wl' wr' -> go fLR wl' wr'
       )
 
--- | Collapse a workflows of workflows into one level
+-- | Collapse a workflow of workflows into one level
 -- Whenever both outer and inner workflows are replaced at the same time, the inner one is ignored
 instance (Apply m, Monad m, Reflex t) => Bind (Workflow t m) where
   join wwa = Workflow $ do

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -32,6 +32,7 @@ import Control.Monad.Fix (MonadFix)
 import Control.Lens (FunctorWithIndex(..), set, (&), (.~))
 
 import Data.Align
+import Data.Align.Indexed (AlignWithIndex)
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Data.Functor.Bind
 import Data.Functor.Plus
@@ -132,6 +133,7 @@ instance (Apply m, Reflex t) => Alt (Workflow t m) where
 #if MIN_VERSION_these(0, 8, 0)
 instance (Apply m, Reflex t) => Semialign (Workflow t m) where
   align = independentWorkflows forwardRender theseOccurrence
+instance (Apply m, Reflex t) => AlignWithIndex Int (Workflow t m)
 #endif
 
 -- | Create a workflow that's replaced when either input workflow is replaced.

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -36,7 +36,7 @@ import Data.Align.Indexed (AlignWithIndex)
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Data.Functor.Bind
 import Data.Functor.Plus
-import Data.These
+import Data.These hiding (swap)
 #if MIN_VERSION_these(0, 8, 0)
 import Data.These.Lens (here, there)
 #endif

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -36,7 +36,9 @@ import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Data.Functor.Bind
 import Data.Functor.Plus
 import Data.These
+#if MIN_VERSION_these(0, 8, 0)
 import Data.These.Lens (here, there)
+#endif
 import Data.Tuple (swap)
 
 import Reflex.Class

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -186,16 +186,16 @@ independentWorkflows = combineWorkflows $ \(_, _) (wa, wb) -> fromThese wa wb
 
 -- | Combine two workflows. The output workflow triggers when either input triggers
 combineWorkflows
-  :: (Functor m, Reflex t, w ~ Workflow t m)
-  => (forall x y. (w x, w y) -> (w x, w y) -> These (w x) (w y) -> (w x, w y))
+  :: (Functor m, Reflex t)
+  => (forall wx wy. (wx, wy) -> (wx, wy) -> These wx wy -> (wx, wy))
   -- ^ Choose the resulting workflows among original, current, and ocurring workflows
   -> (forall x y. (m x, m y) -> m (x,y))
   -- ^ Compute resulting widget
   -> ((a,b) -> These () () -> c)
   -- ^ Compute resulting payload based on current payloads and ocurrences
-  -> w a
-  -> w b
-  -> w c
+  -> Workflow t m a
+  -> Workflow t m b
+  -> Workflow t m c
 combineWorkflows triggerWorflows combineWidgets combineOccurrence wa0 wb0 = go (These () ()) (wa0, wb0)
   where
     go occurring (wa, wb) = Workflow $ ffor (combineWidgets (unWorkflow wa, unWorkflow wb)) $ \((a0, waEv), (b0, wbEv)) ->

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -48,18 +48,67 @@ import Reflex.PostBuild.Class
 -- When the 'Event' returned by a 'Workflow' fires, the current 'Workflow' is replaced by the one inside the firing 'Event'. A series of 'Workflow's must share the same return type.
 newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) } deriving Functor
 
+--------------------------------------------------------------------------------
+-- Running workflows
+--------------------------------------------------------------------------------
+-- | Runs a 'Workflow' and returns the 'Dynamic' result of the 'Workflow' (i.e., a 'Dynamic' of the value produced by the current 'Workflow' node, and whose update 'Event' fires whenever one 'Workflow' is replaced by another).
+workflow :: forall t m a. (Reflex t, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
+workflow w0 = do
+  rec eResult <- networkHold (unWorkflow w0) $ fmap unWorkflow $ switch $ snd <$> current eResult
+  return $ fmap fst eResult
+
+-- | Similar to 'workflow', but outputs an 'Event' that fires whenever the current 'Workflow' is replaced by the next 'Workflow'.
+workflowView :: forall t m a. (Reflex t, NotReady t m, Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
+workflowView w0 = do
+  rec eResult <- networkView . fmap unWorkflow =<< holdDyn w0 eReplace
+      eReplace <- fmap switch $ hold never $ fmap snd eResult
+  return $ fmap fst eResult
+
+--------------------------------------------------------------------------------
+-- Transforming workflows
+--------------------------------------------------------------------------------
+{-# DEPRECATED mapWorkflow "Use 'fmap' instead" #-}
+-- | Map a function over a 'Workflow', possibly changing the return type.
+mapWorkflow :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
+mapWorkflow = fmap
+
+-- | Map a "cheap" function over a 'Workflow'. Refer to the documentation for 'pushCheap' for more information and performance considerations.
+mapWorkflowCheap :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
+mapWorkflowCheap f (Workflow x) = Workflow (fmap (f *** fmapCheap (mapWorkflowCheap f)) x)
+
+zipNEListWithWorkflow :: (Functor m, Reflex t) => NonEmpty k -> Workflow t m a -> Workflow t m (k, a)
+zipNEListWithWorkflow (k :| ks) w = Workflow $ ffor (unWorkflow w) $ \(a0, wEv) ->
+  ((k, a0), case nonEmpty ks of
+      Nothing -> never
+      Just nel -> zipNEListWithWorkflow nel <$> wEv)
+
 instance (Functor m, Reflex t) => FunctorWithIndex Int (Workflow t m) where
   imap f w = uncurry f <$> zipNEListWithWorkflow (0 :| [1..]) w
 
--- | Create a workflow that's replaced when either input workflow is replaced.
--- Occurrences of the left workflow cause the right workflow to be reset
-instance (Apply m, Reflex t) => Apply (Workflow t m) where
-  liftF2 f = chainWorkflows (const $ uncurry f) zipWidgets
+--------------------------------------------------------------------------------
+-- Combining payloads
+--------------------------------------------------------------------------------
+thesePayloads :: ((a,b) -> c) -> ((a,b) -> c) -> ((a,b) -> c) -> These () () -> (a,b) -> c
+thesePayloads fa fb fab = \case
+  This () -> fa
+  That () -> fb
+  These () () -> fab
 
-instance (Apply m, Applicative m, Reflex t) => Applicative (Workflow t m) where
-  pure a = Workflow $ pure (a, never)
-  (<*>) = (<.>)
+leftBiasedLastOccurrence :: These () () -> (a,a) -> a
+leftBiasedLastOccurrence = thesePayloads fst snd fst
 
+ignoreTimings :: ((a,b) -> c) -> These () () -> (a,b) -> c
+ignoreTimings = const
+
+--------------------------------------------------------------------------------
+-- Combining widgets
+--------------------------------------------------------------------------------
+zipWidgets :: Apply f => (f a, f b) -> f (a,b)
+zipWidgets (a,b) = liftF2 (,) a b
+
+--------------------------------------------------------------------------------
+-- Combining workflows
+--------------------------------------------------------------------------------
 instance (Apply m, Reflex t, Semigroup a) => Semigroup (Workflow t m a) where
   (<>) = zipWorkflowsWith (<>)
 
@@ -76,40 +125,14 @@ instance (Apply m, Reflex t) => Semialign (Workflow t m) where
   align = parallelWorkflows (This . fst) (That . snd) (uncurry These) zip
 #endif
 
--- | Collapse a workflow of workflows into one level
--- Whenever both outer and inner workflows are replaced at the same time, the inner one is ignored
-instance (Apply m, Monad m, Reflex t) => Bind (Workflow t m) where
-  join wwa = Workflow $ do
-    let replaceInitial a wa = Workflow $ first (const a) <$> unWorkflow wa
-    (wa0, wwaEv) <- unWorkflow wwa
-    (a0, waEv) <- unWorkflow wa0
-    pure (a0, join <$> leftmost [wwaEv, flip replaceInitial wwa <$> waEv])
+-- | Create a workflow that's replaced when either input workflow is replaced.
+-- Occurrences of the left workflow cause the right workflow to be reset
+instance (Apply m, Reflex t) => Apply (Workflow t m) where
+  liftF2 f = chainWorkflows (const $ uncurry f) zipWidgets
 
-instance (Apply m, Monad m, Reflex t) => Monad (Workflow t m) where
-  (>>=) = (>>-)
-
-
-zipWidgets :: Apply f => (f a, f b) -> f (a,b)
-zipWidgets (a,b) = liftF2 (,) a b
-
-thesePayloads :: ((a,b) -> c) -> ((a,b) -> c) -> ((a,b) -> c) -> These () () -> (a,b) -> c
-thesePayloads fa fb fab = \case
-  This () -> fa
-  That () -> fb
-  These () () -> fab
-
-leftBiasedLastOccurrence :: These () () -> (a,a) -> a
-leftBiasedLastOccurrence = thesePayloads fst snd fst
-
-ignoreTimings :: ((a,b) -> c) -> These () () -> (a,b) -> c
-ignoreTimings = const
-
-zipNEListWithWorkflow :: (Functor m, Reflex t) => NonEmpty k -> Workflow t m a -> Workflow t m (k, a)
-zipNEListWithWorkflow (k :| ks) w = Workflow $ ffor (unWorkflow w) $ \(a0, wEv) ->
-  ((k, a0), case nonEmpty ks of
-      Nothing -> never
-      Just nel -> zipNEListWithWorkflow nel <$> wEv)
-
+instance (Apply m, Applicative m, Reflex t) => Applicative (Workflow t m) where
+  pure a = Workflow $ pure (a, never)
+  (<*>) = (<.>)
 
 -- | Combine two workflows via `combineWorkflows`. Triggers of the first workflow reset the second one.
 chainWorkflows
@@ -165,25 +188,17 @@ combineWorkflows combineP combineW trigger wl0 wr0 = go (These () ()) (wl0, wr0)
              These wl' wr' -> go (These () ()) (t (These wl' wr'))
          )
 
+--------------------------------------------------------------------------------
+-- Flattening workflows
+--------------------------------------------------------------------------------
+-- | Collapse a workflow of workflows into one level
+-- Whenever both outer and inner workflows are replaced at the same time, the inner one is ignored
+instance (Apply m, Monad m, Reflex t) => Bind (Workflow t m) where
+  join wwa = Workflow $ do
+    let replaceInitial a wa = Workflow $ first (const a) <$> unWorkflow wa
+    (wa0, wwaEv) <- unWorkflow wwa
+    (a0, waEv) <- unWorkflow wa0
+    pure (a0, join <$> leftmost [wwaEv, flip replaceInitial wwa <$> waEv])
 
--- | Runs a 'Workflow' and returns the 'Dynamic' result of the 'Workflow' (i.e., a 'Dynamic' of the value produced by the current 'Workflow' node, and whose update 'Event' fires whenever one 'Workflow' is replaced by another).
-workflow :: forall t m a. (Reflex t, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
-workflow w0 = do
-  rec eResult <- networkHold (unWorkflow w0) $ fmap unWorkflow $ switch $ snd <$> current eResult
-  return $ fmap fst eResult
-
--- | Similar to 'workflow', but outputs an 'Event' that fires whenever the current 'Workflow' is replaced by the next 'Workflow'.
-workflowView :: forall t m a. (Reflex t, NotReady t m, Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
-workflowView w0 = do
-  rec eResult <- networkView . fmap unWorkflow =<< holdDyn w0 eReplace
-      eReplace <- fmap switch $ hold never $ fmap snd eResult
-  return $ fmap fst eResult
-
-{-# DEPRECATED mapWorkflow "Use 'fmap' instead" #-}
--- | Map a function over a 'Workflow', possibly changing the return type.
-mapWorkflow :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
-mapWorkflow = fmap
-
--- | Map a "cheap" function over a 'Workflow'. Refer to the documentation for 'pushCheap' for more information and performance considerations.
-mapWorkflowCheap :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
-mapWorkflowCheap f (Workflow x) = Workflow (fmap (f *** fmapCheap (mapWorkflowCheap f)) x)
+instance (Apply m, Monad m, Reflex t) => Monad (Workflow t m) where
+  (>>=) = (>>-)

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -61,6 +62,11 @@ instance (Apply m, Applicative m, Reflex t, Monoid a) => Monoid (Workflow t m a)
 -- The value of the output workflow is taken from the most-recently replaced input workflow.
 instance (Apply m, Reflex t) => Alt (Workflow t m) where
   (<!>) = parallelWorkflows const (flip const) const
+
+#if MIN_VERSION_these(0, 8, 0)
+instance (Apply m, Reflex t) => Semialign (Workflow t m) where
+  align = parallelWorkflows (\a _ -> This a) (\_ b -> That b) These
+#endif
 
 zipWorkflows :: (Apply m, Reflex t) => Workflow t m a -> Workflow t m b -> Workflow t m (a,b)
 zipWorkflows = parallelWorkflows (,) (,) (,)

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -55,7 +55,7 @@ pureW :: (Applicative m, Reflex t) => a -> Workflow t m a
 pureW a = Workflow $ pure (a, never)
 
 -- | Create a workflow that's replaced when either input workflow is replaced.
--- The value of the output workflow is obtained by applying the provided function to the values of the input workflows
+-- Occurrences of the left workflow cause the right workflow to be reset
 instance (Apply m, Monad m, Reflex t) => Apply (Workflow t m) where
   liftF2 f wa wb = join $ ffor wa $ \a -> ffor wb $ \b -> f a b
 
@@ -82,6 +82,8 @@ instance (Apply m, Reflex t) => Semialign (Workflow t m) where
 zipWorkflows :: (Apply m, Reflex t) => Workflow t m a -> Workflow t m b -> Workflow t m (a,b)
 zipWorkflows = zipWorkflowsWith (,)
 
+-- | Create a workflow that's replaced when either input workflow is replaced.
+-- The value of the output workflow is obtained by applying the provided function to the values of the input workflows
 zipWorkflowsWith :: (Apply m, Reflex t) => (a -> b -> c) -> Workflow t m a -> Workflow t m b -> Workflow t m c
 zipWorkflowsWith f = parallelWorkflows f' f' f' zip
   where f' = uncurry f


### PR DESCRIPTION
I was writing `Workflow $ pure (a, never)` a lot in some placeholder code. One thing lead to another and this is what came out of that rabbit hole.

I'll do ~haddocks~ changelog/quickref parts when it's clearer if and which instances we're keeping.

~The `Alt` instance in particular is extremely questionable. The output workflow is replaced whenever either input workflow replacement is triggered, so it's a "last-updated" kind of thing. I don't know how to judge whether this instance is appropriate, since I couldn't find any laws to use as criteria.~
`Alt` actually does list its laws, it's `Alternative` that doesn't seem to.

If anyone wants to mess with these a bit, just do `ob run` in the skeleton folder of https://github.com/alexfmpe/obelisk/tree/test-workflow-instances and visit `http://localhost:8000`