### PR TITLE
fan: Rewrite haddock

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -257,10 +257,10 @@ class ( MonadHold t (PushM t)
   -- least one input event is occurring, and will contain all of the input keys
   -- that are occurring simultaneously
   merge :: GCompare k => DMap k (Event t) -> Event t (DMap k Identity) --TODO: Generalize to get rid of DMap use --TODO: Provide a type-level guarantee that the result is not empty
-  -- | Efficiently fan-out an event to many destinations.  This function should
-  -- be partially applied, and then the result applied repeatedly to create
-  -- child events
-  fan :: GCompare k => Event t (DMap k Identity) -> EventSelector t k --TODO: Can we help enforce the partial application discipline here?  The combinator is worthless without it
+  -- | Efficiently fan-out an event to many destinations.  You should save the
+  -- result in a @let@-binding, and then repeatedly 'select' on the result to
+  -- create child events
+  fan :: GCompare k => Event t (DMap k Identity) -> EventSelector t k
   -- | Create an 'Event' that will occur whenever the currently-selected input
   -- 'Event' occurs
   switch :: Behavior t (Event t a) -> Event t a


### PR DESCRIPTION
It appears that partial application for `fan` went away, but the haddock never changed (how can you partially apply a unary function?).

I have also removed the `TODO` comment, as it seemed no longer relevant. I can re-add it if required.