### PR TITLE
Use align (a merge) instead of coincidence for <.>

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -714,9 +714,9 @@ filterRight = mapMaybe (either (const Nothing) Just)
 instance Reflex t => Alt (Event t) where
   ev1 <!> ev2 = leftmost [ev1, ev2]
 
--- | 'Event' intersection (convenient interface to 'coincidence').
+-- | 'Event' intersection. Only occurs when both events are co-incident.
 instance Reflex t => Apply (Event t) where
-  evf <.> evx = coincidence (fmap (<$> evx) evf)
+  (<.>) = zipWith ($)
 
 -- | 'Event' intersection (convenient interface to 'coincidence').
 instance Reflex t => Bind (Event t) where
@@ -1073,7 +1073,7 @@ instance Reflex t => Align (Event t) where
 instance Reflex t => Semialign (Event t) where
 #endif
   align = alignEventWithMaybe Just
-  
+
 #if defined(MIN_VERSION_semialign)
   zip x y = mapMaybe justThese $ align x y
 #endif

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -716,7 +716,10 @@ instance Reflex t => Alt (Event t) where
 
 -- | 'Event' intersection. Only occurs when both events are co-incident.
 instance Reflex t => Apply (Event t) where
-  (<.>) = zipWith ($)
+  evf <.> evx = mapMaybe f (align evf evx) where
+    f (These g a) = Just (g a)
+    f _           = Nothing
+
 
 -- | 'Event' intersection (convenient interface to 'coincidence').
 instance Reflex t => Bind (Event t) where


### PR DESCRIPTION
coincidence has worse complexity because it invalidates height