### PR TITLE
Fixes for ghc 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
   include:
     - compiler: ghcjs-8.4
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["cabal-install-3.0"]}}
+    - compiler: ghc-8.8.1
+      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
     - compiler: ghc-8.6.5
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.6.5","cabal-install-2.4"]}}
     - compiler: ghc-8.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ script:
   # Constraint set no-th
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --constraint='reflex -use-template-haskell' all | color_cabal_output
   # Constraint set old-these
-  - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --constraint='these <1' all | color_cabal_output
+  - if $GHCJS || ! $GHCJS && [ $HCNUMVER -lt 80800 ] ; then ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --constraint='these <1' all | color_cabal_output ; fi
   # Constraint set old-witherable
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --constraint='witherable <0.3.2' all | color_cabal_output
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -10,6 +10,7 @@ constraint-set no-th
   constraints: reflex -use-template-haskell
 
 constraint-set old-these
+  ghc: <8.8
   constraints: these <1
 
 constraint-set old-witherable

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -50,7 +50,7 @@ library
   hs-source-dirs: src
   build-depends:
     MemoTrie == 0.6.*,
-    base >= 4.9 && < 4.13,
+    base >= 4.9 && < 4.14,
     bifunctors >= 5.2 && < 5.6,
     comonad >= 5.0.4 && < 5.1,
     constraints-extras >= 0.3 && < 0.4,
@@ -63,14 +63,14 @@ library
     mtl >= 2.1 && < 2.3,
     prim-uniq >= 0.1.0.1 && < 0.2,
     primitive >= 0.5 && < 0.8,
-    profunctors >= 5.3 && < 5.5,
+    profunctors >= 5.3 && < 5.6,
     random == 1.1.*,
     ref-tf == 0.4.*,
     reflection == 2.1.*,
     semigroupoids >= 4.0 && < 6,
     stm >= 2.4 && < 2.6,
     syb >= 0.5 && < 0.8,
-    time >= 1.4 && < 1.9,
+    time >= 1.4 && < 1.10,
     transformers >= 0.5.6.0 && < 0.6,
     unbounded-delays >= 0.1.0.0 && < 0.2,
     witherable >= 0.3 && < 0.3.2
@@ -150,9 +150,9 @@ library
     cpp-options: -DUSE_TEMPLATE_HASKELL
     build-depends:
       dependent-sum >= 0.6 && < 0.7,
-      haskell-src-exts >= 1.16 && < 1.22,
+      haskell-src-exts >= 1.16 && < 1.23,
       haskell-src-meta >= 0.6 && < 0.9,
-      template-haskell >= 2.9 && < 2.15
+      template-haskell >= 2.9 && < 2.16
     exposed-modules:
       Reflex.Dynamic.TH
     other-extensions: TemplateHaskell

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -18,7 +18,7 @@ extra-source-files:
   ChangeLog.md
 
 tested-with:
-  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5,
+  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1,
   GHCJS ==8.4
 
 flag use-reflex-optimizer

--- a/release.nix
+++ b/release.nix
@@ -34,6 +34,9 @@ let
                   "release.nix"
                   ".git"
                   "dist"
+                  "cabal.haskell-ci"
+                  "cabal.project"
+                  ".travis.yml"
                 ])) ./.;
               };
             })

--- a/src/Data/Functor/Misc.hs
+++ b/src/Data/Functor/Misc.hs
@@ -53,6 +53,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Some (Some(Some))
 import Data.These
+import Data.Type.Equality ((:~:)(Refl))
 import Data.Typeable hiding (Refl)
 
 --------------------------------------------------------------------------------

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -200,7 +200,7 @@ import Data.Dependent.Map (DMap, DSum (..))
 import qualified Data.Dependent.Map as DMap
 import Data.Functor.Compose
 import Data.Functor.Product
-import Data.GADT.Compare (GEq (..), GCompare (..), (:~:) (..))
+import Data.GADT.Compare (GEq (..), GCompare (..))
 import Data.FastMutableIntMap (PatchIntMap)
 import Data.Foldable
 import Data.Functor.Bind
@@ -215,6 +215,7 @@ import Data.Some (Some(Some))
 import Data.String
 import Data.These
 import Data.Type.Coercion
+import Data.Type.Equality ((:~:) (..))
 import Data.Witherable (Filterable(..))
 import qualified Data.Witherable as W
 import Reflex.FunctorMaybe (FunctorMaybe)

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -663,6 +663,9 @@ instance Reflex t => Monad (Behavior t) where
   a >>= f = pull $ sample a >>= sample . f
   -- Note: it is tempting to write (_ >> b = b); however, this would result in (fail x >> return y) succeeding (returning y), which violates the law that (a >> b = a >>= \_ -> b), since the implementation of (>>=) above actually will fail.  Since we can't examine 'Behavior's other than by using sample, I don't think it's possible to write (>>) to be more efficient than the (>>=) above.
   return = constant
+#if !MIN_VERSION_base(4,13,0)
+  fail = error "Monad (Behavior t) does not support fail"
+#endif
 
 instance (Reflex t, Monoid a) => Monoid (Behavior t a) where
   mempty = constant mempty

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -663,7 +663,6 @@ instance Reflex t => Monad (Behavior t) where
   a >>= f = pull $ sample a >>= sample . f
   -- Note: it is tempting to write (_ >> b = b); however, this would result in (fail x >> return y) succeeding (returning y), which violates the law that (a >> b = a >>= \_ -> b), since the implementation of (>>=) above actually will fail.  Since we can't examine 'Behavior's other than by using sample, I don't think it's possible to write (>>) to be more efficient than the (>>=) above.
   return = constant
-  fail = error "Monad (Behavior t) does not support fail"
 
 instance (Reflex t, Monoid a) => Monoid (Behavior t a) where
   mempty = constant mempty

--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -87,11 +87,12 @@ import Data.Align
 import Data.Dependent.Map (DMap)
 import qualified Data.Dependent.Map as DMap
 import Data.Dependent.Sum (DSum (..))
-import Data.GADT.Compare ((:~:) (..), GCompare (..), GEq (..), GOrdering (..))
+import Data.GADT.Compare (GCompare (..), GEq (..), GOrdering (..))
 import Data.Map (Map)
 import Data.Maybe
 import Data.Monoid ((<>))
 import Data.These
+import Data.Type.Equality ((:~:) (..))
 
 import Debug.Trace
 

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -65,6 +65,7 @@ import Data.Monoid ((<>))
 import Data.Proxy
 import Data.These
 import Data.Traversable
+import Data.Type.Equality ((:~:)(Refl))
 import Data.Witherable (Filterable, mapMaybe)
 import GHC.Exts
 import GHC.IORef (IORef (..))

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -43,6 +43,7 @@ import Control.Monad.Reader.Class
 import Control.Monad.IO.Class
 import Control.Monad.ReaderIO
 import Control.Monad.Ref
+import Control.Monad.Fail (MonadFail)
 import qualified Control.Monad.Fail as MonadFail
 import Data.Align
 import Data.Coerce

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -981,7 +981,7 @@ instance Monad (BehaviorM x) where
 
 instance MonadFail (BehaviorM x) where
   {-# INLINABLE fail #-}
-  fail s = BehaviorM $ fail s
+  fail s = BehaviorM $ MonadFail.fail s
 
 data BehaviorSubscribed x a
    = forall p. BehaviorSubscribedHold (Hold x p)
@@ -2654,7 +2654,7 @@ instance Monad (SpiderHost x) where
 
 instance MonadFail (SpiderHost x) where
   {-# INLINABLE fail #-}
-  fail s = SpiderHost $ fail s
+  fail s = SpiderHost $ MonadFail.fail s
 
 -- | Run an action affecting the global Spider timeline; this will be guarded by
 -- a mutex for that timeline
@@ -2683,7 +2683,7 @@ instance Monad (SpiderHostFrame x) where
 
 instance MonadFail (SpiderHostFrame x) where
   {-# INLINABLE fail #-}
-  fail s = SpiderHostFrame $ fail s
+  fail s = SpiderHostFrame $ MonadFail.fail s
 
 instance NotReady (SpiderTimeline x) (SpiderHostFrame x) where
   notReadyUntil _ = pure ()

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -972,8 +972,10 @@ instance Monad (BehaviorM x) where
   BehaviorM x >> BehaviorM y = BehaviorM $ x >> y
   {-# INLINE return #-}
   return x = BehaviorM $ return x
+#if !MIN_VERSION_base(4,13,0)
   {-# INLINE fail #-}
   fail s = BehaviorM $ fail s
+#endif
 
 data BehaviorSubscribed x a
    = forall p. BehaviorSubscribedHold (Hold x p)
@@ -2357,8 +2359,10 @@ instance HasSpiderTimeline x => Monad (Reflex.Class.Dynamic (SpiderTimeline x)) 
   x >>= f = SpiderDynamic $ dynamicDynIdentity $ newJoinDyn $ newMapDyn (unSpiderDynamic . f) $ unSpiderDynamic x
   {-# INLINE (>>) #-}
   (>>) = (*>)
+#if !MIN_VERSION_base(4,13,0)
   {-# INLINE fail #-}
   fail _ = error "Dynamic does not support 'fail'"
+#endif
 
 {-# INLINABLE newJoinDyn #-}
 newJoinDyn :: HasSpiderTimeline x => DynamicS x (Identity (DynamicS x (Identity a))) -> Reflex.Spider.Internal.Dyn x (Identity a)
@@ -2637,6 +2641,10 @@ instance Monad (SpiderHost x) where
   SpiderHost x >> SpiderHost y = SpiderHost $ x >> y
   {-# INLINABLE return #-}
   return x = SpiderHost $ return x
+#if MIN_VERSION_base(4,13,0)
+
+instance MonadFail (SpiderHost x) where
+#endif
   {-# INLINABLE fail #-}
   fail s = SpiderHost $ fail s
 
@@ -2660,8 +2668,10 @@ instance Monad (SpiderHostFrame x) where
   SpiderHostFrame x >> SpiderHostFrame y = SpiderHostFrame $ x >> y
   {-# INLINABLE return #-}
   return x = SpiderHostFrame $ return x
+#if !MIN_VERSION_base(4,13,0)
   {-# INLINABLE fail #-}
   fail s = SpiderHostFrame $ fail s
+#endif
 
 instance NotReady (SpiderTimeline x) (SpiderHostFrame x) where
   notReadyUntil _ = pure ()

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -979,7 +979,7 @@ instance Monad (BehaviorM x) where
   fail s = MonadFail.fail
 #endif
 
-instance MonadFail (SpiderHost x) where
+instance MonadFail (BehaviorM x) where
   {-# INLINABLE fail #-}
   fail s = BehaviorM $ fail s
 

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -976,12 +976,8 @@ instance Monad (BehaviorM x) where
   return x = BehaviorM $ return x
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINE fail #-}
-  fail s = MonadFail.fail
+  fail s = BehaviorM $ fail s
 #endif
-
-instance MonadFail (BehaviorM x) where
-  {-# INLINABLE fail #-}
-  fail s = BehaviorM $ MonadFail.fail s
 
 data BehaviorSubscribed x a
    = forall p. BehaviorSubscribedHold (Hold x p)
@@ -2649,7 +2645,7 @@ instance Monad (SpiderHost x) where
   return x = SpiderHost $ return x
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINABLE fail #-}
-  fail s = MonadFail.fail
+  fail = MonadFail.fail
 #endif
 
 instance MonadFail (SpiderHost x) where
@@ -2678,12 +2674,8 @@ instance Monad (SpiderHostFrame x) where
   return x = SpiderHostFrame $ return x
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINABLE fail #-}
-  fail s = MonadFail.fail
+  fail s = SpiderHostFrame $ fail s
 #endif
-
-instance MonadFail (SpiderHostFrame x) where
-  {-# INLINABLE fail #-}
-  fail s = SpiderHostFrame $ MonadFail.fail s
 
 instance NotReady (SpiderTimeline x) (SpiderHostFrame x) where
   notReadyUntil _ = pure ()

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -43,6 +43,7 @@ import Control.Monad.Reader.Class
 import Control.Monad.IO.Class
 import Control.Monad.ReaderIO
 import Control.Monad.Ref
+import qualified Control.Monad.Fail as MonadFail
 import Data.Align
 import Data.Coerce
 import Data.Dependent.Map (DMap, DSum (..))
@@ -974,8 +975,12 @@ instance Monad (BehaviorM x) where
   return x = BehaviorM $ return x
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINE fail #-}
-  fail s = BehaviorM $ fail s
+  fail s = MonadFail.fail
 #endif
+
+instance MonadFail (SpiderHost x) where
+  {-# INLINABLE fail #-}
+  fail s = BehaviorM $ fail s
 
 data BehaviorSubscribed x a
    = forall p. BehaviorSubscribedHold (Hold x p)
@@ -2641,10 +2646,12 @@ instance Monad (SpiderHost x) where
   SpiderHost x >> SpiderHost y = SpiderHost $ x >> y
   {-# INLINABLE return #-}
   return x = SpiderHost $ return x
-#if MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_base(4,13,0)
+  {-# INLINABLE fail #-}
+  fail s = MonadFail.fail
+#endif
 
 instance MonadFail (SpiderHost x) where
-#endif
   {-# INLINABLE fail #-}
   fail s = SpiderHost $ fail s
 
@@ -2670,8 +2677,12 @@ instance Monad (SpiderHostFrame x) where
   return x = SpiderHostFrame $ return x
 #if !MIN_VERSION_base(4,13,0)
   {-# INLINABLE fail #-}
-  fail s = SpiderHostFrame $ fail s
+  fail s = MonadFail.fail
 #endif
+
+instance MonadFail (SpiderHostFrame x) where
+  {-# INLINABLE fail #-}
+  fail s = SpiderHostFrame $ fail s
 
 instance NotReady (SpiderTimeline x) (SpiderHostFrame x) where
   notReadyUntil _ = pure ()


### PR DESCRIPTION
Moves `fail` from `Monad` instances when using ghc 8.8.1
and instead includes `MonadFail` where `fail` is needed.

Fixes #377