### PR TITLE
WIP: New workflows

### DIFF
--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 -- |
 -- Module:
 --   Reflex.Workflow
@@ -16,30 +20,39 @@ module Reflex.Workflow (
   ) where
 
 import Control.Arrow ((***))
+import Control.Lens (makePrisms, preview)
+import Control.Monad (ap, (<=<), (>=>))
 import Control.Monad.Fix (MonadFix)
-
+import Data.Functor.Bind
+import Data.Maybe (fromMaybe)
 import Reflex.Class
 import Reflex.Adjustable.Class
-import Reflex.Network
-import Reflex.NotReady.Class
 import Reflex.PostBuild.Class
 
+--------------------------------------------------------------------------------
+-- Workflow
+--------------------------------------------------------------------------------
 -- | A widget in a workflow
 -- When the 'Event' returned by a 'Workflow' fires, the current 'Workflow' is replaced by the one inside the firing 'Event'. A series of 'Workflow's must share the same return type.
 newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) }
 
--- | Runs a 'Workflow' and returns the 'Dynamic' result of the 'Workflow' (i.e., a 'Dynamic' of the value produced by the current 'Workflow' node, and whose update 'Event' fires whenever one 'Workflow' is replaced by another).
-workflow :: forall t m a. (Reflex t, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
-workflow w0 = do
-  rec eResult <- networkHold (unWorkflow w0) $ fmap unWorkflow $ switch $ snd <$> current eResult
-  return $ fmap fst eResult
+-- | Runs a 'Workflow' and returns the initial value together with an 'Event' that fires whenever one 'Workflow' is replaced by another.
+runWorkflow :: (Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (a, Event t a)
+runWorkflow w0 = mdo
+  ((a, e0), eResult) <- runWithReplace (unWorkflow w0) (fmap unWorkflow eReplace)
+  eReplace <- switchHold e0 $ fmap snd eResult
+  return (a, fmap fst eResult)
 
--- | Similar to 'workflow', but outputs an 'Event' that fires at post-build time and whenever the current 'Workflow' is replaced by the next 'Workflow'.
-workflowView :: forall t m a. (Reflex t, NotReady t m, Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
-workflowView w0 = do
-  rec eResult <- networkView . fmap unWorkflow =<< holdDyn w0 eReplace
-      eReplace <- fmap switch $ hold never $ fmap snd eResult
-  return $ fmap fst eResult
+-- | Similar to 'runWorkflow' but combines the result into a 'Dynamic'.
+workflow :: (Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Dynamic t a)
+workflow = uncurry holdDyn <=< runWorkflow
+
+-- | Similar to 'runWorkflow', but also puts the initial value in the 'Event'.
+workflowView :: (Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
+workflowView w = do
+  postBuildEv <- getPostBuild
+  (initialValue, replaceEv) <- runWorkflow w
+  pure $ leftmost [initialValue <$ postBuildEv, replaceEv]
 
 -- | Map a function over a 'Workflow', possibly changing the return type.
 mapWorkflow :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
@@ -48,3 +61,78 @@ mapWorkflow f (Workflow x) = Workflow (fmap (f *** fmap (mapWorkflow f)) x)
 -- | Map a "cheap" function over a 'Workflow'. Refer to the documentation for 'pushCheap' for more information and performance considerations.
 mapWorkflowCheap :: (Reflex t, Functor m) => (a -> b) -> Workflow t m a -> Workflow t m b
 mapWorkflowCheap f (Workflow x) = Workflow (fmap (f *** fmapCheap (mapWorkflowCheap f)) x)
+
+--------------------------------------------------------------------------------
+-- Wizard
+--------------------------------------------------------------------------------
+newtype Wizard t m a = Wizard { unWizard :: m (WizardInternal t m a) } deriving Functor
+data WizardInternal t m a
+  = WizardInternal_Terminal a
+  | WizardInternal_Update (Event t a)
+  | WizardInternal_Replace (Event t (Wizard t m a))
+  deriving Functor
+makePrisms ''WizardInternal
+
+step :: Functor m => m (Event t a) -> Wizard t m a
+step = Wizard . fmap WizardInternal_Update
+
+runWizard :: forall t m a. (Adjustable t m, MonadHold t m, MonadFix m, PostBuild t m) => Wizard t m a -> m (Event t a)
+runWizard w = mdo
+  let getReplace = fromMaybe never . preview _WizardInternal_Replace
+      getUpdate = fromMaybe never . preview _WizardInternal_Update
+  (wint0, wintEv) <- runWithReplace (unWizard w) $ leftmost [unWizard <$> replace, pure . WizardInternal_Terminal <$> updates]
+  replace <- switchHold (getReplace wint0) (getReplace <$> wintEv)
+  updates <- switchHold (getUpdate wint0) (getUpdate <$> wintEv)
+  pb <- getPostBuild
+  let terminal0 = maybe never (<$ pb) $ preview _WizardInternal_Terminal wint0
+      terminal = fmapMaybe (preview _WizardInternal_Terminal) wintEv
+  pure $ leftmost [terminal0, terminal]
+
+instance (Monad m, Reflex t) => Apply (Wizard t m) where
+  (<.>) = ap
+
+instance (Monad m, Reflex t) => Applicative (Wizard t m) where
+  pure = Wizard . pure . WizardInternal_Terminal
+  (<*>) = (<.>)
+
+instance (Monad m, Reflex t) => Bind (Wizard t m) where
+  join ww = Wizard $ unWizard ww >>= \case
+    WizardInternal_Terminal (Wizard w) -> w
+    WizardInternal_Update ev -> pure $ WizardInternal_Replace ev
+    WizardInternal_Replace ev -> pure $ WizardInternal_Replace $ ffor ev join
+
+instance (Monad m, Reflex t) => Monad (Wizard t m) where
+  (>>=) = (>>-)
+
+--------------------------------------------------------------------------------
+-- Stack
+--------------------------------------------------------------------------------
+newtype Stack t m a = Stack { unStack :: m (a, Event t a) } deriving Functor
+
+frame :: m (a, Event t a) -> Stack t m a
+frame = Stack
+
+stackHold :: MonadHold t m => Stack t m a -> m (Dynamic t a)
+stackHold = unStack >=> uncurry holdDyn
+
+stackView :: PostBuild t m => Stack t m a -> m (Event t a)
+stackView = unStack >=> \(a, ev) -> do
+  pb <- getPostBuild
+  pure $ leftmost [a <$ pb, ev]
+
+instance (Adjustable t m, MonadHold t m, PostBuild t m) => Apply (Stack t m) where
+  (<.>) = ap
+
+instance (Adjustable t m, MonadHold t m, PostBuild t m) => Applicative (Stack t m) where
+  pure = Stack . pure . (, never)
+  (<*>) = (<.>)
+
+instance (Adjustable t m, MonadHold t m, PostBuild t m) => Bind (Stack t m) where
+  join ss = frame $ do
+    (s0, sEv) <- unStack ss
+    ((a0,ev0), ev) <- runWithReplace (unStack s0) $ unStack <$> sEv
+    e <- switchHold never $ fmap snd ev
+    pure (a0, leftmost [ev0, fmap fst ev, e])
+
+instance (Adjustable t m, MonadHold t m, PostBuild t m) => Monad (Stack t m) where
+  (>>=) = (>>-)


### PR DESCRIPTION
For examples, see https://github.com/alexfmpe/obelisk/tree/ae%40test-new-workflows which currently has this code inlined for faster prototyping. Now that `ob run` supports loading dependencies into its repl, I'll switch to that instead.

The advantage of both `Wizard` and `Stack` over `Workflow` is that they can be composed much more easily. A `Workflow` declares all its future replacements up-front, while `Wizard` and `Stack` pieces can be created from a `m (Event t a)` and a life-cycle is then specified by chaining several widgets via bind or do-notation. AFAICT this is similar to [Concur](https://github.com/ajnsit/concur-documentation/blob/master/README.md#a-quick-tour-of-concur)'s `Widget`

Only one layer of a `Wizard` exists at any given time. Each time a wizard layer triggers its `Event`, it is completely replaced by the following one.
`Wizard` is adapted from https://github.com/reflex-frp/reflex/compare/workflow-monad. 

All layers of a `Stack` are present at the same time. Each time one layer triggers its `Event`, all following ones are replaced. A `Stack` can be made incremental with recourse to `MaybeT`.
`Stack` (or rather, something that looked similar but was completely bugged) was discovered by accident while trying to get away with type tetris and failing miserably.

The same temporal flow can be re-used for `Stack` and `Wizard`:
```haskell
let 
  someFlow mkWorkflow x0 = do
    x1 <- mkWorkflow x0
    x2 <- mkWorkflow x1
    x3 <- mkWorkflow x2
    pure x3

  wizardFlow = someFlow $
    step . someButton

  stackFlow = runMaybeT $ someFlow $
    MaybeT . frame . fmap (\ev -> (Nothing, fmap Just ev)) . someButton
```
To-do in no particular order:
- [ ] Add documentation (where do examples go?)
- [ ] Review typeclasses/constraints. I made a beeline for `Bind`/`Monad` and didn't pay much attention to the rest.
- [ ] Test for leaks
- [ ] Test for simultaneous occurrences
- [ ] Investigate relationship between `Workflow` and `Wizard`
- [ ] Try to make incremental stacks more ergonomic
- [ ] Try to make wizard/stack agnostic flows more ergonomic
- [ ] Try to make nesting of wizards/stacks/workflows more ergonomic
