### PR TITLE
Lifting instances for `Reflex.Profiled`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add lifting instances for most classes to `Reflex.Profiled.Profiled`.
 * Class `MonadQuery t q m` now has a `Monad m` superclass constraint.
 * Rename class `MonadBehaviorWriter` -> `BehaviorWriter` for
   consistency with `EventWriter`/`DynamicWriter`.


### PR DESCRIPTION
@mpickering asked me whether it was possible to use `Reflex.Profiled`
with `reflex-basic-host`. I said that it probably wouldn't be too
hard, you'd just need lifts here and there.

This PR adds lifting instances for all the classes I could find in
`reflex`, and tidies up a couple of warts I found along the way. I
don't really understand `Reflex.Profiled` (I just hit things with
`coerce` and `lift` until GHC was happy), so please look closely to
make sure useful things aren't getting dropped on the floor.