### PR TITLE
Rename MonadBehaviorWriter -> BehaviorWriter; deprecate old name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for reflex
 
+## Unreleased
+
+* Rename class `MonadBehaviorWriter` -> `BehaviorWriter` for
+  consistency with `EventWriter`/`DynamicWriter`.
+* Introduce deprecated alias `MonadBehaviorWriter = BehaviorWriter`.
+
 ## 0.6.4.1
 
 * Fix a bug in the Reflex Profiled transformer where

--- a/src/Reflex/BehaviorWriter/Base.hs
+++ b/src/Reflex/BehaviorWriter/Base.hs
@@ -1,6 +1,6 @@
 {-|
 Module: Reflex.BehaviorWriter.Base
-Description: Implementation of MonadBehaviorWriter
+Description: Implementation of BehaviorWriter
 -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -46,7 +46,7 @@ import Reflex.Query.Class
 import Reflex.Requester.Class
 import Reflex.TriggerEvent.Class
 
--- | A basic implementation of 'MonadBehaviorWriter'.
+-- | A basic implementation of 'BehaviorWriter'.
 newtype BehaviorWriterT t w m a = BehaviorWriterT { unBehaviorWriterT :: StateT [Behavior t w] m a }
   deriving (Functor, Applicative, Monad, MonadIO, MonadFix, MonadAsyncException, MonadException) -- The list is kept in reverse order
 
@@ -89,7 +89,7 @@ instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (BehaviorWri
   newEventWithTrigger = lift . newEventWithTrigger
   newFanEventWithTrigger f = lift $ newFanEventWithTrigger f
 
-instance (Monad m, Monoid w, Reflex t) => MonadBehaviorWriter t w (BehaviorWriterT t w m) where
+instance (Monad m, Monoid w, Reflex t) => BehaviorWriter t w (BehaviorWriterT t w m) where
   tellBehavior w = BehaviorWriterT $ modify (w :)
 
 instance MonadReader r m => MonadReader r (BehaviorWriterT t w m) where

--- a/src/Reflex/BehaviorWriter/Class.hs
+++ b/src/Reflex/BehaviorWriter/Class.hs
@@ -1,8 +1,9 @@
 {-|
 Module: Reflex.BehaviorWriter.Class
-Description: This module defines the 'MonadBehaviorWriter' class
+Description: This module defines the 'BehaviorWriter' class
 -}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -10,16 +11,21 @@ Description: This module defines the 'MonadBehaviorWriter' class
 {-# OPTIONS_GHC -fplugin=Reflex.Optimizer #-}
 #endif
 module Reflex.BehaviorWriter.Class
-  ( MonadBehaviorWriter (..)
+  ( MonadBehaviorWriter
+  , BehaviorWriter(..)
   ) where
 
 import Control.Monad.Reader (ReaderT, lift)
 import Reflex.Class (Behavior)
 
--- | 'MonadBehaviorWriter' efficiently collects 'Behavior' values using 'tellBehavior'
+{-# DEPRECATED MonadBehaviorWriter "Use 'BehaviorWriter' instead" #-}
+-- | Type synonym for 'BehaviorWriter'
+type MonadBehaviorWriter = BehaviorWriter
+
+-- | 'BehaviorWriter' efficiently collects 'Behavior' values using 'tellBehavior'
 -- and combines them monoidally to provide a 'Behavior' result.
-class (Monad m, Monoid w) => MonadBehaviorWriter t w m | m -> t w where
+class (Monad m, Monoid w) => BehaviorWriter t w m | m -> t w where
   tellBehavior :: Behavior t w -> m ()
 
-instance MonadBehaviorWriter t w m => MonadBehaviorWriter t w (ReaderT r m) where
+instance BehaviorWriter t w m => BehaviorWriter t w (ReaderT r m) where
   tellBehavior = lift . tellBehavior


### PR DESCRIPTION
For consistency with EventWriter/DynamicWriter classes.


----

#