### PR TITLE
Add NOINLINE pragma to mkFastWeakTicket

### DIFF
--- a/src/Reflex/FastWeak.hs
+++ b/src/Reflex/FastWeak.hs
@@ -151,6 +151,16 @@ getFastWeakTicket w = do
 
 -- | Create a 'FastWeakTicket' directly from a value, creating a 'FastWeak' in the process
 -- which can be obtained with 'getFastWeakTicketValue'.
+--
+-- This function is marked NOINLINE so it is opaque to GHC.
+-- If we do not do this, then GHC will sometimes fuse the constructor away
+-- so any weak references that are attached to the ticket will have their
+-- finalizer run. Using the opaque constructor, GHC does not see the
+-- constructor application, so it behaves like an IORef and cannot be fused away.
+--
+-- The result is also evaluated to WHNF, since forcing a thunk invalidates
+-- the weak pointer to it in some cases.
+{-# NOINLINE mkFastWeakTicket #-}
 mkFastWeakTicket :: a -> IO (FastWeakTicket a)
 -- I think it's fine if this is lazy - it'll retain the 'a', but so would the output; we just need to make sure it's forced before we start relying on the
 -- associated FastWeak to actually be weak

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -450,16 +450,6 @@ data Subscriber x a = Subscriber
   , subscriberRecalculateHeight :: !(Height -> IO ())
   }
 
---TODO: Move this comment to WeakBag
--- These function are constructor functions that are marked NOINLINE so they are
--- opaque to GHC. If we do not do this, then GHC will sometimes fuse the constructor away
--- so any weak references that are attached to the constructors will have their
--- finalizer run. Using the opaque constructor, does not see the
--- constructor application, so it behaves like an IORef and cannot be fused away.
---
--- The result is also evaluated to WHNF, since forcing a thunk invalidates
--- the weak pointer to it in some cases.
-
 newSubscriberHold :: (HasSpiderTimeline x, Patch p) => Hold x p -> IO (Subscriber x p)
 newSubscriberHold h = return $ Subscriber
   { subscriberPropagate = {-# SCC "traverseHold" #-} propagateSubscriberHold h


### PR DESCRIPTION
(Also move what I think is the corresponding comment)

Without this NOINLINE, the FastWeakTicket can be fused away (in
cacheSubscription in particular), causing early unsubscriptions.

This manifested itself in reflex-dom-core as items in a nested list
never being added to the DOM, because runWithReplace in the immediate
builder was being unsubscribed from the lifted runWithReplace result
events.