### PR TITLE
Bump version bounds

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -73,7 +73,7 @@ library
     monad-control >= 1.0.1 && < 1.1,
     mtl >= 2.1 && < 2.3,
     patch >= 0.0.1 && < 0.1,
-    prim-uniq >= 0.1.0.1 && < 0.2,
+    prim-uniq >= 0.1.0.1 && < 0.3,
     primitive >= 0.5 && < 0.8,
     profunctors >= 5.3 && < 5.6,
     random == 1.1.*,
@@ -85,10 +85,10 @@ library
     time >= 1.4 && < 1.10,
     transformers >= 0.5.6.0 && < 0.6,
     unbounded-delays >= 0.1.0.0 && < 0.2,
-    witherable >= 0.3 && < 0.3.2
+    witherable >= 0.3 && < 0.4
 
   if flag(split-these)
-    build-depends:     these >= 1 && <1.1,
+    build-depends:     these >= 1 && <1.2,
                        semialign >=1 && <1.2,
                        monoidal-containers >= 0.6 && < 0.7
   else
@@ -170,8 +170,8 @@ library
   if flag(use-template-haskell)
     cpp-options: -DUSE_TEMPLATE_HASKELL
     build-depends:
-      dependent-sum >= 0.6 && < 0.7,
-      haskell-src-exts >= 1.16 && < 1.23,
+      dependent-sum >= 0.6 && < 0.8,
+      haskell-src-exts >= 1.16 && < 1.24,
       haskell-src-meta >= 0.6 && < 0.9,
       template-haskell >= 2.9 && < 2.16
     exposed-modules:
@@ -179,7 +179,7 @@ library
     other-extensions: TemplateHaskell
   else
     build-depends:
-      dependent-sum >= 0.6 && < 0.7
+      dependent-sum >= 0.6 && < 0.8
 
   if flag(fast-weak) && impl(ghcjs)
     cpp-options: -DGHCJS_FAST_WEAK


### PR DESCRIPTION
I have successfully build reflex with those dependencies in nixpkgs.

I would very much appreciate a hackage revision with these version bounds updated.