### PR TITLE
Coincidence fails between two unrelated events

### DIFF
--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -178,11 +178,6 @@ testCases =
       switchHoldPromptly never $ flip pushAlways e $
         const (switchHoldPromptly e never)
 
-  , testE "switchHoldPromptly-7" $ do
-      e1 <- events1
-      e2 <- events2
-      pure . coincidence . pushAlways (\_ -> switchHoldPromptly e1 never) $ e2
-
   , testE "coincidence-1" $ do
       e <- events1
       return $ coincidence $ flip pushAlways e $
@@ -218,6 +213,11 @@ testCases =
   , testE "coincidence-7" $ do
       e <- events1
       return $ coincidence (deep e <$ e)
+
+  , testE "coincidence-8" $ do
+      e1 <- events1
+      e2 <- events2
+      pure . coincidence . fmap (const e1) $ e2
 
   , testB "holdWhileFiring" $ do
       e <- events1

--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -178,6 +178,11 @@ testCases =
       switchHoldPromptly never $ flip pushAlways e $
         const (switchHoldPromptly e never)
 
+  , testE "switchHoldPromptly-7" $ do
+      e1 <- events1
+      e2 <- events2
+      pure . coincidence . pushAlways (\_ -> switchHoldPromptly e1 never) $ e2
+
   , testE "coincidence-1" $ do
       e <- events1
       return $ coincidence $ flip pushAlways e $


### PR DESCRIPTION
I ran into some unexpected behavior where spider doesn't produce an occurrence when asking coincidences of an unrelated event within another like so:

```
coincidence . fmap (const e1) $ e2
```

I've added a test case for it but I don't have a fix. It might be relevant to know that it also happens with `pushCheap` instead of `push`/`fmap`.
