### PR TITLE
fix: check on headless exit on post build

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -342,6 +342,14 @@ test-suite RequesterT
     Reflex.Plan.Pure
     Test.Run
 
+test-suite Headless
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: Headless.hs
+  hs-source-dirs: test
+  build-depends: base
+               , reflex
+
 test-suite Adjustable
   default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/test/Headless.hs
+++ b/test/Headless.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Reflex
+import Reflex.Host.Headless (runHeadlessApp)
+
+main :: IO ()
+main = do
+  runHeadlessApp $ do
+    pb <- getPostBuild
+    performEvent (pure <$> pb)


### PR DESCRIPTION
Don't enter the headless main loop if there's a shutdown request upon post build.

Without this check, if the application immediately requests shut down on a post build action, the application fails with a `thread blocked indefinitely in an MVar operation` instead of exiting gracefully.

An example use case is trying to read a file on post build, but failing as the file cannot be found. The application would handle this issue as it sees fit and immediately request exit, but fail to do so.