### PR TITLE
Mmorph shouldn't be needed yet

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -70,7 +70,6 @@ library
     dependent-map >= 0.3 && < 0.5,
     exception-transformers == 0.4.*,
     lens >= 4.7 && < 5,
-    mmorph >= 1.0 && < 1.2,
     monad-control >= 1.0.1 && < 1.1,
     mtl >= 2.1 && < 2.3,
     patch >= 0.0.1 && < 0.1,


### PR DESCRIPTION
This as an oversight in backporting the GHC 8.10 support.