### PR TITLE
Merge a few things in from v0.7.1.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,6 @@
 name: github-action
 
-on: [push, pull_request] 
+on: [push, pull_request]
 
 jobs:
   build:
@@ -8,12 +8,6 @@ jobs:
       matrix:
         ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.2']
         os: ['ubuntu-latest', 'macos-latest']
-        exclude:
-          # There are some linker warnings in 802 on darwin that
-          # cause compilation to fail
-          # See https://github.com/NixOS/nixpkgs/issues/25139
-          - ghc: '8.0.2'
-            os: 'macos-latest'
     runs-on: ${{ matrix.os }}
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
@@ -43,3 +37,5 @@ jobs:
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
       run: cabal test all
+    - name: Build Docs
+      run: cabal haddock

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,14 +3,25 @@
 ## 0.8.1.0
 
 * Add support for GHC 8.10
-* Drop support for GHC 8.2.* and earlier
+* Drop support for GHC < 8.4
 
 ## 0.8.0.0
 
 * Replace 0.7.2.0 with 0.8.0.0 to reflect the `MonadHold` interface change. Deprecates 0.7.2.0.
 
-## 0.7.2.0
+## 0.7.2.0 -- *Deprecated*
+
 * ([#416](https://github.com/reflex-frp/reflex/pull/416)) Add `now :: m (Event t ())` to `MonadHold`.
+* Extend some dependency version bounds
+* Fix HLint 3 test
+
+## 0.7.1.1
+
+*Backport release*.
+Changes do not carry forward to 0.7.2.0.
+
+* Add support for GHC 8.10
+* Drop support for GHC < 8.4
 * Extend some dependency version bounds
 * Fix HLint 3 test
 

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -29,7 +29,7 @@ extra-source-files:
 
 tested-with:
   GHC  ==8.4.4 || ==8.6.5 || ==8.8.1 || ==8.10.2,
-  GHCJS ==8.4
+  GHCJS ==8.6
 
 flag use-reflex-optimizer
   description: Use the GHC plugin Reflex.Optimizer on some of the modules in the package.  This is still experimental.
@@ -71,7 +71,7 @@ library
   hs-source-dirs: src
   build-depends:
     MemoTrie == 0.6.*,
-    base >= 4.9 && < 4.15,
+    base >= 4.11 && < 4.15,
     bifunctors >= 5.2 && < 5.6,
     comonad >= 5.0.4 && < 5.1,
     constraints-extras >= 0.3 && < 0.4,


### PR DESCRIPTION
- Clean up GitHub action
- Complete change log
- Fix GHCJS tested version
- Bump base lower bound because we in fact do not build with 8.2 and earlier.