### PR TITLE
doc: Update function refrence

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -1028,7 +1028,7 @@ switchHoldPromptly ea0 eea = do
 
 -- | switches to a new event whenever it receives one.  At the moment of
 -- switching, the old event will be ignored if it fires, and the new one will be
--- used if it fires; this is the opposite of 'switch', which will use only the
+-- used if it fires; this is the opposite of 'switchHold', which will use only the
 -- old value.
 --
 -- 'switchHold', by always forwarding the old event the moment it is switched


### PR DESCRIPTION
I could be misunderstanding, but it seems like `switchHoldPromptOnly` has the opposite behavior of `switchHold` and not `switch`