### PR TITLE
Avoid TH compat CPP

### DIFF
--- a/src/Reflex/Dynamic/TH.hs
+++ b/src/Reflex/Dynamic/TH.hs
@@ -44,16 +44,15 @@ qDynPure qe = do
         _ -> gmapM f d
   (e', exprsReversed) <- runStateT (gmapM f e) []
   let exprs = reverse exprsReversed
-      arg = foldr (\a b -> ConE 'FHCons `AppE` snd a `AppE` b) (ConE 'FHNil) exprs
-      param = foldr (\a b -> conPCompat 'HCons [VarP (fst a), b]) (conPCompat 'HNil []) exprs
-  [| $(return $ LamE [param] e') <$> distributeFHListOverDynPure $(return arg) |]
-
-conPCompat :: Name -> [Pat] -> Pat
-#if MIN_VERSION_template_haskell(2, 18, 0)
-conPCompat name = ConP name []
-#else
-conPCompat = ConP
-#endif
+      arg = foldr
+        (\(_, expr) rest -> [e| FHCons $(pure expr) $rest |])
+        [e| FHNil |]
+        exprs
+      param = foldr
+        (\(name, _) rest -> [p| HCons $(pure $ VarP name) $rest |])
+        [p| HNil |]
+        exprs
+  [| (\ $param -> $(pure e')) <$> distributeFHListOverDynPure $arg |]
 
 -- | Antiquote a 'Dynamic' expression.  This can /only/ be used inside of a
 -- 'qDyn' quotation.


### PR DESCRIPTION
Instead of using the prone-to-breakage TH AST, use quoting and splicing.