### PR TITLE
Fix/build with nixpkgs 22 05

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -75,6 +75,7 @@ library
     base >= 4.11 && < 4.17,
     bifunctors >= 5.2 && < 5.6,
     comonad >= 5.0.4 && < 5.1,
+    commutative-semigroups >= 0.1 && < 1,
     constraints >= 0.10 && <0.14,
     constraints-extras >= 0.3 && < 0.4,
     containers >= 0.6 && < 0.7,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -1,6 +1,5 @@
 Name: reflex
-Version: 0.8.2.0
-x-revision: 2
+Version: 0.8.3.0
 Synopsis: Higher-order Functional Reactive Programming
 Description:
   Interactive programs without callbacks or side-effects.

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -74,7 +74,7 @@ library
     base >= 4.11 && < 4.17,
     bifunctors >= 5.2 && < 5.6,
     comonad >= 5.0.4 && < 5.1,
-    commutative-semigroups >= 0.1 && < 1,
+    commutative-semigroups >= 0.0.2 && < 0.2,
     constraints >= 0.10 && <0.14,
     constraints-extras >= 0.3 && < 0.4,
     containers >= 0.6 && < 0.7,

--- a/reflex.cabal
+++ b/reflex.cabal
@@ -377,6 +377,7 @@ test-suite QueryT
   main-is: QueryT.hs
   hs-source-dirs: test
   build-depends: base
+               , commutative-semigroups
                , containers
                , dependent-map
                , dependent-sum

--- a/src/Data/AppendMap.hs
+++ b/src/Data/AppendMap.hs
@@ -30,7 +30,7 @@ import qualified Data.Map.Internal.Debug as Map (showTree, showTreeWith)
 #else
 import qualified Data.Map as Map (showTree, showTreeWith)
 #endif
-import qualified Data.Witherable as W
+import qualified Witherable as W
 import Data.Map.Monoidal
 import qualified Data.Map.Monoidal as MonoidalMap
 

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -218,8 +218,8 @@ import Data.String
 import Data.These
 import Data.Type.Coercion
 import Data.Type.Equality ((:~:) (..))
-import Data.Witherable (Filterable(..))
-import qualified Data.Witherable as W
+import Witherable (Filterable(..))
+import qualified Witherable as W
 import Reflex.FunctorMaybe (FunctorMaybe)
 import qualified Reflex.FunctorMaybe
 import Data.Patch

--- a/src/Reflex/FunctorMaybe.hs
+++ b/src/Reflex/FunctorMaybe.hs
@@ -19,7 +19,7 @@ import Data.Map (Map)
 #if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option(..))
 #endif
-import Data.Witherable
+import Witherable
 
 --TODO: See if there's a better class in the standard libraries already
 

--- a/src/Reflex/Query/Base.hs
+++ b/src/Reflex/Query/Base.hs
@@ -42,6 +42,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Monoid ((<>))
 import qualified Data.Semigroup as S
+import Data.Semigroup.Commutative
 import Data.Some (Some(Some))
 import Data.These
 
@@ -64,7 +65,7 @@ newtype QueryT t q m a = QueryT { unQueryT :: StateT [Behavior t q] (EventWriter
 deriving instance MonadHold t m => MonadHold t (QueryT t q m)
 deriving instance MonadSample t m => MonadSample t (QueryT t q m)
 
-runQueryT :: (MonadFix m, Additive q, Group q, Reflex t) => QueryT t q m a -> Dynamic t (QueryResult q) -> m (a, Incremental t (AdditivePatch q))
+runQueryT :: (MonadFix m, Commutative q, Group q, Reflex t) => QueryT t q m a -> Dynamic t (QueryResult q) -> m (a, Incremental t (AdditivePatch q))
 runQueryT (QueryT a) qr = do
   ((r, bs), es) <- runReaderT (runEventWriterT (runStateT a mempty)) qr
   return (r, unsafeBuildIncremental (foldlM (\b c -> (b <>) <$> sample c) mempty bs) (fmapCheap AdditivePatch es))
@@ -80,7 +81,7 @@ getQueryTLoweredResultWritten (QueryTLoweredResult (_, w)) = w
 maskMempty :: (Eq a, Monoid a) => a -> Maybe a
 maskMempty x = if x == mempty then Nothing else Just x
 
-instance (Reflex t, MonadFix m, Group q, Additive q, Query q, Eq q, MonadHold t m, Adjustable t m) => Adjustable t (QueryT t q m) where
+instance (Reflex t, MonadFix m, Commutative q, Group q, Query q, Eq q, MonadHold t m, Adjustable t m) => Adjustable t (QueryT t q m) where
   runWithReplace (QueryT a0) a' = do
     ((r0, bs0), r') <- QueryT $ lift $ runWithReplace (runStateT a0 []) $ fmapCheap (flip runStateT [] . unQueryT) a'
     let sampleBs :: forall m'. MonadSample t m' => [Behavior t q] -> m' q
@@ -283,7 +284,7 @@ instance (S.Semigroup a, Monad m) => S.Semigroup (QueryT t q m a) where
   (<>) = liftA2 (S.<>)
 
 -- | withQueryT's QueryMorphism argument needs to be a group homomorphism in order to behave correctly
-withQueryT :: (MonadFix m, PostBuild t m, Group q, Group q', Additive q, Additive q', Query q')
+withQueryT :: (MonadFix m, PostBuild t m, Commutative q, Commutative q', Group q, Group q', Query q')
            => QueryMorphism q q'
            -> QueryT t q m a
            -> QueryT t q' m a
@@ -300,7 +301,7 @@ mapQueryT :: (forall b. m b -> n b) -> QueryT t q m a -> QueryT t q n a
 mapQueryT f (QueryT a) = QueryT $ mapStateT (mapEventWriterT (mapReaderT f)) a
 
 -- | dynWithQueryT's (Dynamic t QueryMorphism) argument needs to be a group homomorphism at all times in order to behave correctly
-dynWithQueryT :: (MonadFix m, PostBuild t m, Group q, Additive q, Group q', Additive q', Query q')
+dynWithQueryT :: (MonadFix m, PostBuild t m, Commutative q, Commutative q', Group q, Group q', Query q')
            => Dynamic t (QueryMorphism q q')
            -> QueryT t q m a
            -> QueryT t q' m a
@@ -325,7 +326,7 @@ dynWithQueryT f q = do
                    return $ Just $ AdditivePatch $ mconcat [ g a bOld, negateG (g aOld bOld), g a b]
          in unsafeBuildIncremental (g <$> sample (current da) <*> sample (currentIncremental ib)) ec
 
-instance (Monad m, Group q, Additive q, Query q, Reflex t) => MonadQuery t q (QueryT t q m) where
+instance (Monad m, Group q, Commutative q,  Query q, Reflex t) => MonadQuery t q (QueryT t q m) where
   tellQueryIncremental q = do
     QueryT (modify (currentIncremental q:))
     QueryT (lift (tellEvent (fmapCheap unAdditivePatch (updatedIncremental q))))

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -66,7 +66,7 @@ import Data.Proxy
 import Data.These
 import Data.Traversable
 import Data.Type.Equality ((:~:)(Refl))
-import Data.Witherable (Filterable, mapMaybe)
+import Witherable (Filterable, mapMaybe)
 import GHC.Exts hiding (toList)
 import GHC.IORef (IORef (..))
 import GHC.Stack

--- a/test/DebugCycles.hs
+++ b/test/DebugCycles.hs
@@ -29,7 +29,7 @@ import Reflex.EventWriter.Base
 import Test.Run
 import Test.Hspec
 import Reflex.Spider.Internal (EventLoopException)
-import Data.Witherable (Filterable)
+import Witherable (Filterable)
 
 #if defined(MIN_VERSION_these_lens) || (MIN_VERSION_these(0,8,0) && !MIN_VERSION_these(0,9,0))
 import Data.These.Lens

--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -17,6 +17,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Map.Monoidal (MonoidalMap)
 import Data.Semigroup
+import Data.Semigroup.Commutative
 import Data.These
 
 #if defined(MIN_VERSION_these_lens) || (MIN_VERSION_these(0,8,0) && !MIN_VERSION_these(0,9,0))
@@ -28,7 +29,7 @@ import Data.Patch.MapWithMove
 import Test.Run
 
 newtype MyQuery = MyQuery SelectedCount
-  deriving (Show, Read, Eq, Ord, Monoid, Semigroup, Additive, Group)
+  deriving (Show, Read, Eq, Ord, Monoid, Semigroup, Commutative, Group)
 
 instance Query MyQuery where
   type QueryResult MyQuery = ()
@@ -62,7 +63,6 @@ instance (Ord k, Eq a, Monoid a, Align (MonoidalMap k)) => Monoid (Selector k a)
 instance (Eq a, Ord k, Group a, Align (MonoidalMap k)) => Group (Selector k a) where
   negateG = fmap negateG
 
-instance (Eq a, Ord k, Group a, Align (MonoidalMap k)) => Additive (Selector k a)
 
 main :: IO ()
 main = do

--- a/test/QueryT.hs
+++ b/test/QueryT.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -30,6 +31,8 @@ import Test.Run
 
 newtype MyQuery = MyQuery SelectedCount
   deriving (Show, Read, Eq, Ord, Monoid, Semigroup, Commutative, Group)
+
+instance Commutative (Selector Int MyQuery)
 
 instance Query MyQuery where
   type QueryResult MyQuery = ()


### PR DESCRIPTION
With NixOS 22.05 reflex doesn't  compile. 

```sh
nix-shell -p "haskell.packages.ghc8107.ghcWithPackages (pkgs: with pkgs; [])" -p cabal-install
cabal test -fsplit-these
```

I also replaced the deprecated import Data.Witherable by Witherable
