### PR TITLE
Fix build against ghc 9.6 under '--allow-newer'

### DIFF
--- a/src/Reflex/BehaviorWriter/Base.hs
+++ b/src/Reflex/BehaviorWriter/Base.hs
@@ -21,7 +21,9 @@ module Reflex.BehaviorWriter.Base
   , withBehaviorWriterT
   ) where
 
+import Control.Monad
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.IO.Class
 import Control.Monad.Morph

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -185,6 +185,8 @@ import Data.Zip (Zip (..), Unzip (..))
 #endif
 
 import Control.Applicative
+import Control.Monad
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State.Strict

--- a/src/Reflex/Collection.hs
+++ b/src/Reflex/Collection.hs
@@ -34,8 +34,10 @@ import Data.Zip (Zip (..))
 #endif
 #endif
 
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Data.Align
+import Data.Functor
 import Data.Functor.Misc
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/Reflex/Dynamic.hs
+++ b/src/Reflex/Dynamic.hs
@@ -99,7 +99,7 @@ import Data.Monoid ((<>))
 import Data.These
 import Data.Type.Equality ((:~:) (..))
 
-import Debug.Trace
+import Debug.Trace (trace)
 
 -- | Map a sampling function over a 'Dynamic'.
 mapDynM :: forall t m a b. (Reflex t, MonadHold t m) => (forall m'. MonadSample t m' => a -> m' b) -> Dynamic t a -> m (Dynamic t b)

--- a/src/Reflex/DynamicWriter/Base.hs
+++ b/src/Reflex/DynamicWriter/Base.hs
@@ -19,7 +19,9 @@ module Reflex.DynamicWriter.Base
   , withDynamicWriterT
   ) where
 
+import Control.Monad
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.IO.Class
 import Control.Monad.Morph

--- a/src/Reflex/EventWriter/Base.hs
+++ b/src/Reflex/EventWriter/Base.hs
@@ -35,6 +35,7 @@ import Reflex.TriggerEvent.Class
 
 import Control.Monad.Exception
 import Control.Monad.Identity
+import Control.Monad.Fix
 import Control.Monad.Morph
 import Control.Monad.Primitive
 import Control.Monad.Reader

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -33,6 +33,7 @@ import Reflex.Requester.Class
 
 import Control.Lens
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Primitive
 import Control.Monad.Reader

--- a/src/Reflex/PerformEvent/Class.hs
+++ b/src/Reflex/PerformEvent/Class.hs
@@ -20,6 +20,7 @@ module Reflex.PerformEvent.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe (MaybeT (..))
 
+import Data.Functor
 import Data.Kind (Type)
 
 import Reflex.Class

--- a/src/Reflex/PostBuild/Base.hs
+++ b/src/Reflex/PostBuild/Base.hs
@@ -30,6 +30,7 @@ import Reflex.TriggerEvent.Class
 
 import Control.Applicative (liftA2)
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Primitive
 import Control.Monad.Reader

--- a/src/Reflex/Requester/Base/Internal.hs
+++ b/src/Reflex/Requester/Base/Internal.hs
@@ -32,7 +32,9 @@ import Reflex.Requester.Class
 import Reflex.TriggerEvent.Class
 
 import Control.Applicative (liftA2)
+import Control.Monad
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Morph
 import Control.Monad.Primitive

--- a/src/Reflex/Requester/Class.hs
+++ b/src/Reflex/Requester/Class.hs
@@ -18,6 +18,7 @@ module Reflex.Requester.Class
  , requestingIdentity
  ) where
 
+import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Reader
 import qualified Control.Monad.State.Lazy as Lazy

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -36,6 +36,7 @@ import Control.Concurrent
 import Control.Exception
 import Control.Monad hiding (forM, forM_, mapM, mapM_)
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Identity hiding (forM, forM_, mapM, mapM_)
 import Control.Monad.Primitive
 import Control.Monad.Reader.Class

--- a/src/Reflex/TriggerEvent/Base.hs
+++ b/src/Reflex/TriggerEvent/Base.hs
@@ -16,6 +16,7 @@ module Reflex.TriggerEvent.Base
 import Control.Applicative (liftA2)
 import Control.Concurrent
 import Control.Monad.Exception
+import Control.Monad.Fix
 import Control.Monad.Primitive
 import Control.Monad.Reader
 import Control.Monad.Ref


### PR DESCRIPTION
https://github.com/haskell/mtl/blob/master/CHANGELOG.markdown#23----2022-05-07

https://hackage.haskell.org/package/base-4.18.0.0/docs/Debug-Trace.html#v:traceEventWith
The `since 4.17` annotation suggests we should have hit this with #486 as well but it's [wrong](https://gitlab.haskell.org/ghc/ghc/-/commit/2aa0770845631e4355f55694f49b3e4b66ecf751#cbecf35546dee344ca6fb2e73c7515f07e868d0f_307_306) 


