### PR TITLE
Reflex.Network: improve haddocks

### DIFF
--- a/src/Reflex/Network.hs
+++ b/src/Reflex/Network.hs
@@ -22,7 +22,7 @@ import Reflex.PostBuild.Class
 -- | A 'Dynamic' "network": Takes a 'Dynamic' of network-creating actions and replaces the network whenever the 'Dynamic' updates.
 -- The returned Event of network results fires at post-build time and when the 'Dynamic' updates.
 -- Note:  Often, the type 'a' is an Event, in which case the return value is an Event-of-Events, where the outer 'Event' fires
--- when switching networks. Such an 'Event' would typically be flattened (via 'switchPromptly').
+-- when switching networks. Such an 'Event' would typically be flattened (via 'switchHoldPromptly').
 networkView :: (NotReady t m, Adjustable t m, PostBuild t m) => Dynamic t (m a) -> m (Event t a)
 networkView child = do
   postBuild <- getPostBuild
@@ -30,8 +30,8 @@ networkView child = do
   snd <$> runWithReplace notReady newChild
 
 -- | Given an initial "network" and an 'Event' of network-creating actions, create a network that is recreated whenever the Event fires.
---   The returned Dynamic of network results occurs when the Event does.
---   Note:  Often, the type 'a' is an Event, in which case the return value is a Dynamic-of-Events that would typically be flattened.
+-- The returned Dynamic of network results occurs when the Event does.
+-- Note:  Often, the type 'a' is an Event, in which case the return value is a Dynamic-of-Events that would typically be flattened (via 'switchPromptlyDyn').
 networkHold :: (Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m (Dynamic t a)
 networkHold child0 newChild = do
   (result0, newResult) <- runWithReplace child0 newChild


### PR DESCRIPTION
* Replace reference to deprecated function with its replacement
* Normalise comment formatting
* Suggest how to flatten the result of `networkHold`