### PR TITLE
Fix `matchResponseMapWithRequests` to handle prompt response.

### DIFF
--- a/src/Reflex/Requester/Base/Internal.hs
+++ b/src/Reflex/Requester/Base/Internal.hs
@@ -59,6 +59,7 @@ import Data.Monoid ((<>))
 import Data.Proxy
 import qualified Data.Semigroup as S
 import Data.Some (Some(Some))
+import Data.These
 import Data.Type.Equality
 import Data.Unique.Tag
 
@@ -547,12 +548,18 @@ matchResponseMapWithRequests
 matchResponseMapWithRequests f send recv = do
   rec nextId <- hold 1 $ fmap (\(next, _, _) -> next) outgoing
       waitingFor :: Incremental t (PatchMap Int (Decoder rawResponse response)) <-
-        holdIncremental mempty $ leftmost
-          [ fmap (\(_, outstanding, _) -> outstanding) outgoing
-          , snd <$> incoming
-          ]
+        holdIncremental mempty $
+          alignEventWithMaybe
+            ( Just . \case
+                These x y -> y <> x
+                This x -> x
+                That x -> x
+            )
+            outstanding
+            (snd <$> incoming)
       let outgoing = processOutgoing nextId send
-          incoming = processIncoming waitingFor recv
+          incoming = processIncoming waitingFor outstanding recv
+          outstanding = fmap (\(_, outstanding, _) -> outstanding) outgoing
   return (fmap (\(_, _, rawReqs) -> rawReqs) outgoing, fst <$> incoming)
   where
     -- Tags each outgoing request with an identifying integer key
@@ -570,12 +577,15 @@ matchResponseMapWithRequests f send recv = do
       -- The new next-available-key, a map of requests expecting responses, and the tagged raw requests
     processOutgoing nextId out = flip pushAlways out $ \dm -> do
       oldNextId <- sample nextId
-      let (result, newNextId) = flip runState oldNextId $ forM (requesterDataToList dm) $ \(k :=> v) -> do
+      let (result, newNextId) = flip runState oldNextId $
+            forM (requesterDataToList dm) $ \(k :=> v) -> do
             n <- get
             put $ succ n
             let (rawReq, rspF) = f v
             return (n, rawReq, Decoder k rspF)
-          patchWaitingFor = PatchMap $ Map.fromList $
+          patchWaitingFor =
+            PatchMap $
+              Map.fromList $
             (\(n, _, dec) -> (n, Just dec)) <$> result
           toSend = Map.fromList $ (\(n, rawReq, _) -> (n, rawReq)) <$> result
       return (newNextId, patchWaitingFor, toSend)
@@ -583,18 +593,30 @@ matchResponseMapWithRequests f send recv = do
     -- decoders and returns the decoded response and a patch that can
     -- be used to clear the ID of the consumed response out of the queue
     -- of expected responses.
-    processIncoming
+    processIncoming 
       :: Incremental t (PatchMap Int (Decoder rawResponse response))
       -- A map of outstanding expected responses
+      -> Event t (PatchMap Int (Decoder rawResponse response))
+      -- A map of response decoders for prompt responses
       -> Event t (Map Int rawResponse)
       -- A incoming response paired with its identifying key
       -> Event t (RequesterData response, PatchMap Int v)
       -- The decoded response and a patch that clears the outstanding responses queue
-    processIncoming waitingFor inc = flip push inc $ \rspMap -> do
-      wf <- sample $ currentIncremental waitingFor
+    processIncoming waitingFor outstanding inc = flip push (alignEventWithMaybe thatMaybe inc outstanding) $ \(rspMap, promptRspMap) -> do
+      wf' <- sample $ currentIncremental waitingFor
+      let wf = maybe id applyAlways promptRspMap wf'
       let match rawRsp (Decoder k rspF) =
             let rsp = rspF rawRsp
             in singletonRequesterData k rsp
           matches = Map.intersectionWith match rspMap wf
-      pure $ if Map.null matches then Nothing else Just
+      pure $
+        if Map.null matches
+          then Nothing
+          else
+            Just
         (Map.foldl' mergeRequesterData emptyRequesterData matches, PatchMap $ Nothing <$ matches)
+    thatMaybe :: These a b -> Maybe (a, Maybe b)
+    thatMaybe = \case
+      This x -> Just (x, Nothing)
+      That x -> Nothing
+      These x y -> Just (x, Just y)

--- a/src/Reflex/Requester/Base/Internal.hs
+++ b/src/Reflex/Requester/Base/Internal.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE RecursiveDo #-}

--- a/src/Reflex/Requester/Base/Internal.hs
+++ b/src/Reflex/Requester/Base/Internal.hs
@@ -22,8 +22,8 @@
 #endif
 module Reflex.Requester.Base.Internal where
 
-import Reflex.Class
 import Reflex.Adjustable.Class
+import Reflex.Class
 import Reflex.Dynamic
 import Reflex.EventWriter.Class
 import Reflex.Host.Class
@@ -34,7 +34,7 @@ import Reflex.TriggerEvent.Class
 
 import Control.Applicative (liftA2)
 import Control.Monad
-import Control.Monad.Catch (MonadMask, MonadThrow, MonadCatch)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Exception
 import Control.Monad.Fix
 import Control.Monad.Identity
@@ -59,7 +59,7 @@ import qualified Data.Map as Map
 import Data.Monoid ((<>))
 import Data.Proxy
 import qualified Data.Semigroup as S
-import Data.Some (Some(Some))
+import Data.Some (Some (Some))
 import Data.These
 import Data.Type.Equality
 import Data.Unique.Tag
@@ -550,14 +550,8 @@ matchResponseMapWithRequests f send recv = do
   rec nextId <- hold 1 $ fmap (\(next, _, _) -> next) outgoing
       waitingFor :: Incremental t (PatchMap Int (Decoder rawResponse response)) <-
         holdIncremental mempty $
-          alignEventWithMaybe
-            ( Just . \case
-                These x y -> y <> x
-                This x -> x
-                That x -> x
-            )
-            outstanding
-            (snd <$> incoming)
+          (snd <$> incoming) <> outstanding
+
       let outgoing = processOutgoing nextId send
           incoming = processIncoming waitingFor outstanding recv
           outstanding = fmap (\(_, outstanding, _) -> outstanding) outgoing
@@ -594,7 +588,7 @@ matchResponseMapWithRequests f send recv = do
     -- decoders and returns the decoded response and a patch that can
     -- be used to clear the ID of the consumed response out of the queue
     -- of expected responses.
-    processIncoming 
+    processIncoming
       :: Incremental t (PatchMap Int (Decoder rawResponse response))
       -- A map of outstanding expected responses
       -> Event t (PatchMap Int (Decoder rawResponse response))


### PR DESCRIPTION
```haskell
app :: forall t m. (MonadHeadlessApp t m) => m (Event t ())
app = mdo
  ePostBuild <- getPostBuild

  rec (_, eRequest) <-
        runRequesterT
          ( do
              eX <-
                requesting (ePostBuild $> Const ())
              performEvent_ $ ffor eX (const $ liftIO $ print "Got Response!")
          )
          eResponse'
      (eRequest', eResponse') <-
        matchResponseMapWithRequests
          (\x -> (mkSome x, \case Some x -> unsafeCoerce x))
          eRequest
          eResponse
      eResponse <- pure $ ffor eRequest' $ fmap (\(Some req) -> Some (Identity 1))
  pure never
  ```
This minimal example demonstrates a request/response interaction. When a request is made, the corresponding response is generated immediately, as seen in the `eResponse` definition. However, the current implementation of `matchResponseMapWithRequests` doesn't correctly handle prompt responses, resulting in "Got Response!" not being printed from `eX`. This fix ensures that prompt responses are handled correctly, allowing "Got Response!" to be printed as expected.