### PR TITLE
Add note about `requesting` semantics

### DIFF
--- a/src/Reflex/Requester/Class.hs
+++ b/src/Reflex/Requester/Class.hs
@@ -39,6 +39,8 @@ class (Reflex t, Monad m) => Requester t m | m -> t where
   type Response m :: Type -> Type
   -- | Emit a request whenever the given 'Event' fires, and return responses in
   -- the resulting 'Event'.
+  --
+  -- Semantically, the response event occurs at a later time than the request event.
   requesting :: Event t (Request m a) -> m (Event t (Response m a))
   -- | Emit a request whenever the given 'Event' fires, and ignore all responses.
   requesting_ :: Event t (Request m a) -> m ()


### PR DESCRIPTION
This seems to be the case for Obelisk's HTTP requester. Should it be true in general? Is this the right place to document it?

Being explicit about this matters to me, because it's possible to implement a requester has the request and response events fire at the same time.
If that were the case, then you wouldn't be able to, say, transition a DOM element to "loading" while a request was in flight.
