### PR TITLE
Remove unused proctest dependency

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -310,7 +310,6 @@ test-suite DebugCycles
                , reflex
                , ref-tf
                , witherable
-               , proctest
 
 
   if flag(split-these)


### PR DESCRIPTION
Fixes CI which started failing recently since `text` 2.1.2 broke `proctest` build and thus a test suite here. 
`proctest` is not actually used here, only declared so easy fix.
https://github.com/haskell/text/pull/608
https://github.com/alexfmpe/reflex/actions/runs/11654426219/job/32447941922#step:5:948

```
Error:     Ambiguous occurrence ‘show’
    It could refer to
       either ‘Prelude.show’,
Error: cabal: Failed to build proctest-0.1.3.0. See the build log above for
details.

              imported from ‘Prelude’ at Test/Proctest.hs:65:8-20
              (and originally defined in ‘GHC.Show’)
           or ‘Data.Text.show’,
              imported from ‘Data.Text’ at Test/Proctest.hs:104:1-16
    |
196 |     msg = "Test.Proctest.Timeout: " ++ show n ++ " microseconds do not fit into Int"
    |                                        ^^^^
Error: Process completed with exit code 1.
```