### PR TITLE
Lazy sampling allowing the removal of `buildDynamic`, introducing `liftPushM`

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -156,6 +156,7 @@ module Reflex.Class
     -- * Deprecated functions
   , switchPromptly
   , switchPromptOnly
+  , buildDynamic
   -- * "Cheap" functions
   , fmapMaybeCheap
   , mapMaybeCheap
@@ -388,6 +389,11 @@ instance (Reflex t, Default a) => Default (Dynamic t a) where
 class (Applicative m, Monad m) => MonadSample t m | m -> t where
   -- | Get the current value in the 'Behavior'
   sample :: Behavior t a -> m a
+  {-# INLINABLE sample #-}
+  default sample :: (m ~ f m', MonadTrans f, MonadSample t m') => Behavior t a -> m a
+  sample = lift . sample
+
+{-# DEPRECATED buildDynamic "Sample directly and use 'liftPusmM'" #-}
 
 -- | 'MonadHold' designates monads that can create new 'Behavior's based on
 -- 'Event's; usually this will be 'PushM' or a monad based on it.  'MonadHold'
@@ -400,33 +406,50 @@ class MonadSample t m => MonadHold t m where
   -- the 'Behavior', it will see the __old__ value of the 'Behavior', not the new
   -- one.
   hold :: a -> Event t a -> m (Behavior t a)
+  {-# INLINABLE hold #-}
   default hold :: (m ~ f m', MonadTrans f, MonadHold t m') => a -> Event t a -> m (Behavior t a)
   hold v0 = lift . hold v0
   -- | Create a 'Dynamic' value using the given initial value that changes every
   -- time the 'Event' occurs.
   holdDyn :: a -> Event t a -> m (Dynamic t a)
+  {-# INLINABLE holdDyn #-}
   default holdDyn :: (m ~ f m', MonadTrans f, MonadHold t m') => a -> Event t a -> m (Dynamic t a)
   holdDyn v0 = lift . holdDyn v0
   -- | Create an 'Incremental' value using the given initial value that changes
   -- every time the 'Event' occurs.
   holdIncremental :: Patch p => PatchTarget p -> Event t p -> m (Incremental t p)
+  {-# INLINABLE holdIncremental #-}
   default holdIncremental :: (Patch p, m ~ f m', MonadTrans f, MonadHold t m') => PatchTarget p -> Event t p -> m (Incremental t p)
   holdIncremental v0 = lift . holdIncremental v0
+  -- | DEPRECATED. This function allowed for extra laziness when sampling
+  -- behaviors, but is no longer needed. When implementing MonadHold use the new
+  -- 'liftPushM' instead.
   buildDynamic :: PushM t a -> Event t a -> m (Dynamic t a)
-  {-
-  default buildDynamic :: (m ~ f m', MonadTrans f, MonadHold t m') => PullM t a -> Event t a -> m (Dynamic t a)
-  buildDynamic getV0 = lift . buildDynamic getV0
-  -}
+  buildDynamic initialValue e = do
+    iv <- liftPushM initialValue
+    holdDyn iv e
   -- | Create a new 'Event' that only occurs only once, on the first occurrence of
   -- the supplied 'Event'.
   headE :: Event t a -> m (Event t a)
+  {-# INLINABLE headE #-}
+  default headE :: (m ~ f m', MonadTrans f, MonadHold t m') => Event t a -> m (Event t a)
+  headE = lift . headE
   -- | An event which only occurs at the current moment in time, such that:
   --
   -- > coincidence (pushAlways (\a -> (a <$) <$> now) e) = e
   --
   now :: m (Event t ())
+  {-# INLINABLE now #-}
   default now :: (m ~ f m', MonadTrans f, MonadHold t m') => m (Event t ())
   now = lift now
+  {-# INLINABLE liftPushM #-}
+  liftPushM :: PushM t a -> m a
+  {- -- When buildDynamic has been removed this can be the new default:
+  default liftPushM :: (m ~ f m', MonadTrans f, MonadHold t m') => PushM t a -> m a
+  liftPushM = lift . liftPushM
+  -}
+  default liftPushM :: (Reflex t) => PushM t a -> m a
+  liftPushM m = sample . current =<< buildDynamic m never
 
 -- | Accumulate an 'Incremental' with the supplied initial value and the firings of the provided 'Event',
 -- using the combining function to produce a patch.
@@ -570,9 +593,9 @@ instance MonadHold t m => MonadHold t (ReaderT r m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 instance (MonadSample t m, Monoid r) => MonadSample t (WriterT r m) where
   sample = lift . sample
@@ -581,9 +604,9 @@ instance (MonadHold t m, Monoid r) => MonadHold t (WriterT r m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 instance MonadSample t m => MonadSample t (StateT s m) where
   sample = lift . sample
@@ -592,9 +615,9 @@ instance MonadHold t m => MonadHold t (StateT s m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 instance MonadSample t m => MonadSample t (ExceptT e m) where
   sample = lift . sample
@@ -603,9 +626,9 @@ instance MonadHold t m => MonadHold t (ExceptT e m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 instance (MonadSample t m, Monoid w) => MonadSample t (RWST r w s m) where
   sample = lift . sample
@@ -614,9 +637,9 @@ instance (MonadHold t m, Monoid w) => MonadHold t (RWST r w s m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 instance MonadSample t m => MonadSample t (ContT r m) where
   sample = lift . sample
@@ -625,9 +648,9 @@ instance MonadHold t m => MonadHold t (ContT r m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0
-  buildDynamic a0 = lift . buildDynamic a0
   headE = lift . headE
   now = lift now
+  liftPushM = lift . liftPushM
 
 --------------------------------------------------------------------------------
 -- Convenience functions

--- a/src/Reflex/EventWriter/Base.hs
+++ b/src/Reflex/EventWriter/Base.hs
@@ -141,12 +141,12 @@ instance MonadHold t m => MonadHold t (EventWriterT t w m) where
   holdDyn v0 = lift . holdDyn v0
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 = lift . holdIncremental v0
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic a0 = lift . buildDynamic a0
   {-# INLINABLE headE #-}
   headE = lift . headE
   {-# INLINABLE now #-}
   now = lift now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = lift . liftPushM
 
 instance (Reflex t, Adjustable t m, MonadHold t m, Semigroup w) => Adjustable t (EventWriterT t w m) where
   runWithReplace = runWithReplaceEventWriterTWith $ \dm0 dm' -> lift $ runWithReplace dm0 dm'

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -164,12 +164,12 @@ instance (ReflexHost t, MonadHold t m) => MonadHold t (PerformEventT t m) where
   holdDyn v0 v' = PerformEventT $ lift $ holdDyn v0 v'
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 v' = PerformEventT $ lift $ holdIncremental v0 v'
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 v' = PerformEventT $ lift $ buildDynamic getV0 v'
   {-# INLINABLE headE #-}
   headE = PerformEventT . lift . headE
   {-# INLINABLE now #-}
   now = PerformEventT . lift $ now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = PerformEventT . lift . liftPushM
 
 instance (MonadRef (HostFrame t), ReflexHost t) => MonadRef (PerformEventT t m) where
   type Ref (PerformEventT t m) = Ref (HostFrame t)

--- a/src/Reflex/PostBuild/Base.hs
+++ b/src/Reflex/PostBuild/Base.hs
@@ -94,12 +94,12 @@ instance MonadHold t m => MonadHold t (PostBuildT t m) where
   holdDyn v0 = lift . holdDyn v0
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 = lift . holdIncremental v0
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic a0 = lift . buildDynamic a0
   {-# INLINABLE headE #-}
   headE = lift . headE
   {-# INLINABLE now #-}
   now = lift now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = lift . liftPushM
 
 instance PerformEvent t m => PerformEvent t (PostBuildT t m) where
   type Performable (PostBuildT t m) = Performable m

--- a/src/Reflex/Profiled.hs
+++ b/src/Reflex/Profiled.hs
@@ -188,9 +188,9 @@ instance MonadHold t m => MonadHold (ProfiledTimeline t) (ProfiledM m) where
   hold v0 (Event_Profiled v') = ProfiledM $ Behavior_Profiled <$> hold v0 v'
   holdDyn v0 (Event_Profiled v') = ProfiledM $ Dynamic_Profiled <$> holdDyn v0 v'
   holdIncremental v0 (Event_Profiled v') = ProfiledM $ Incremental_Profiled <$> holdIncremental v0 v'
-  buildDynamic (ProfiledM v0) (Event_Profiled v') = ProfiledM $ Dynamic_Profiled <$> buildDynamic v0 v'
   headE (Event_Profiled e) = ProfiledM $ Event_Profiled <$> headE e
   now = ProfiledM $ Event_Profiled <$> now
+  liftPushM (ProfiledM m) = ProfiledM . liftPushM $ m
 
 instance MonadSample t m => MonadSample (ProfiledTimeline t) (ProfiledM m) where
   sample (Behavior_Profiled b) = ProfiledM $ sample b

--- a/src/Reflex/Pure.hs
+++ b/src/Reflex/Pure.hs
@@ -186,12 +186,14 @@ instance (Enum t, HasTrie t, Ord t) => MonadHold (Pure t) ((->) t) where
             else let lastTime = pred sampleTime
                  in fromMaybe (f lastTime) $ unEvent e lastTime
 
-  holdDyn v0 = buildDynamic (return v0)
+  holdDyn v0 e = do
+    b <- hold v0 e
+    pure $ unsafeDynamic b e
 
   buildDynamic :: (t -> a) -> Event (Pure t) a -> t -> Dynamic (Pure t) a
-  buildDynamic initialValue e initialTime =
-    let Behavior f = hold (initialValue initialTime) e initialTime
-    in Dynamic $ \t -> (f t, unEvent e t)
+  buildDynamic initialValue e = do
+    iv <- initialValue
+    holdDyn iv e
 
   holdIncremental :: Patch p => PatchTarget p -> Event (Pure t) p -> t -> Incremental (Pure t) p
   holdIncremental initialValue e initialTime = Incremental $ \t -> (f t, unEvent e t)

--- a/src/Reflex/Pure.hs
+++ b/src/Reflex/Pure.hs
@@ -190,11 +190,6 @@ instance (Enum t, HasTrie t, Ord t) => MonadHold (Pure t) ((->) t) where
     b <- hold v0 e
     pure $ unsafeDynamic b e
 
-  buildDynamic :: (t -> a) -> Event (Pure t) a -> t -> Dynamic (Pure t) a
-  buildDynamic initialValue e = do
-    iv <- initialValue
-    holdDyn iv e
-
   holdIncremental :: Patch p => PatchTarget p -> Event (Pure t) p -> t -> Incremental (Pure t) p
   holdIncremental initialValue e initialTime = Incremental $ \t -> (f t, unEvent e t)
     where f = memo $ \sampleTime ->
@@ -211,3 +206,4 @@ instance (Enum t, HasTrie t, Ord t) => MonadHold (Pure t) ((->) t) where
 
   headE = slowHeadE
   now t = Event $ guard . (t ==)
+  liftPushM = id

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -293,14 +293,28 @@ subscribeAndReadHead e sub = do
     Just _ -> unsubscribe subscription
   return (subscription, occ)
 
-headE :: Defer (SomeMergeInit x) m => Event x a -> m (Event x a)
+headE :: (HasSpiderTimeline x, Defer (SomeMergeInit x) m) => Event x a -> m (Event x a)
 headE originalE = do
   parent <- liftIO $ newIORef $ Just originalE
-  defer $ SomeMergeInit $ do --TODO: Rename SomeMergeInit appropriately
-    let clearParent = liftIO $ writeIORef parent Nothing
-    (_, occ) <- subscribeAndReadHead originalE $ terminalSubscriber $ const clearParent
-    when (isJust occ) clearParent
-  return $ Event $ \sub ->
+  -- guardRef retains the merge-init subscription so GC cannot collect it
+  -- before the original event fires. Without this, the terminalSubscriber's
+  -- callback might never run, breaking headE's "at most once" semantics.
+  guardRef <- liftIO $ newIORef (Nothing :: Maybe (EventSubscription x))
+  defer $ SomeMergeInit $ do
+    -- Use scheduleClear instead of writing parent directly: the clear is
+    -- deferred to the end of runFrame, so same-frame subscribers still see
+    -- the current occurrence (matching slowHeadE's hold/switch semantics).
+    (subscription, occ) <- subscribeAndReadHead originalE $
+      terminalSubscriber $ \_ -> do
+        scheduleClear parent
+        liftIO $ writeIORef guardRef Nothing
+    if isJust occ
+      then do
+        scheduleClear parent
+        liftIO $ writeIORef guardRef Nothing
+      else liftIO $ writeIORef guardRef $ Just subscription
+  return $ Event $ \sub -> do
+    liftIO $ touch guardRef
     liftIO (readIORef parent) >>= \case
       Nothing -> subscribeAndReadNever
       Just e -> subscribeAndReadHead e sub

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2514,15 +2514,13 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Event
   holdDyn = holdDynSpiderEventM
   {-# INLINABLE holdIncremental #-}
   holdIncremental = holdIncrementalSpiderEventM
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic (SpiderPushM getV0) e = do
-    v0 <- getV0
-    R.holdDyn v0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = nowSpiderEventM
+  {-# INLINABLE liftPushM #-}
+  liftPushM (SpiderPushM m) = m
 
 instance Reflex.Class.MonadSample (SpiderTimeline x) (SpiderPullM x) where
   {-# INLINABLE sample #-}
@@ -2539,13 +2537,13 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   holdDyn v0 (SpiderEvent e) = SpiderPushM $ fmap (SpiderDynamic . dynamicHoldIdentity) $ Reflex.Spider.Internal.hold v0 $ coerce e
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 (SpiderEvent e) = SpiderPushM $ SpiderIncremental . dynamicHold <$> Reflex.Spider.Internal.hold v0 e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = SpiderPushM $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderPushM $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderPushM nowSpiderEventM
+  {-# INLINABLE liftPushM #-}
+  liftPushM = id
 
 
 instance HasSpiderTimeline x => Monad (Reflex.Class.Dynamic (SpiderTimeline x)) where
@@ -2597,12 +2595,12 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   holdDyn v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdDyn v0 e
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdIncremental v0 e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = runFrame . runSpiderHostFrame $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE e = runFrame . runSpiderHostFrame $ Reflex.Class.headE e
   {-# INLINABLE now #-}
   now = runFrame . runSpiderHostFrame $ Reflex.Class.now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = runFrame . runSpiderHostFrame . Reflex.Class.liftPushM
 
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHostFrame x) where
@@ -2615,13 +2613,13 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   holdDyn v0 e = SpiderHostFrame $ fmap (SpiderDynamic . dynamicHoldIdentity) $ Reflex.Spider.Internal.hold v0 $ coerce $ unSpiderEvent e
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 e = SpiderHostFrame $ fmap (SpiderIncremental . dynamicHold) $ Reflex.Spider.Internal.hold v0 $ unSpiderEvent e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = SpiderHostFrame $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderHostFrame Reflex.Class.now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = SpiderHostFrame . Reflex.Class.liftPushM
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHost x) where
   {-# INLINABLE sample #-}
@@ -2638,12 +2636,12 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Refle
   holdDyn v0 e = Reflex.Spider.Internal.ReadPhase $ Reflex.Class.holdDyn v0 e
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 e = Reflex.Spider.Internal.ReadPhase $ Reflex.Class.holdIncremental v0 e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = Reflex.Spider.Internal.ReadPhase $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE e = Reflex.Spider.Internal.ReadPhase $ Reflex.Class.headE e
   {-# INLINABLE now #-}
   now = Reflex.Spider.Internal.ReadPhase Reflex.Class.now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = Reflex.Spider.Internal.ReadPhase . Reflex.Class.liftPushM
 
 --------------------------------------------------------------------------------
 -- Deprecated items

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -293,7 +293,6 @@ subscribeAndReadHead e sub = do
     Just _ -> unsubscribe subscription
   return (subscription, occ)
 
---TODO: Make this lazy in its input event
 headE :: Defer (SomeMergeInit x) m => Event x a -> m (Event x a)
 headE originalE = do
   parent <- liftIO $ newIORef $ Just originalE
@@ -2515,8 +2514,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Event
   {-# INLINABLE holdIncremental #-}
   holdIncremental = holdIncrementalSpiderEventM
   {-# INLINABLE headE #-}
-  headE = R.slowHeadE
---  headE (SpiderEvent e) = SpiderEvent <$> Reflex.Spider.Internal.headE e
+  headE (SpiderEvent e) = SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = nowSpiderEventM
   {-# INLINABLE liftPushM #-}
@@ -2538,8 +2536,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 (SpiderEvent e) = SpiderPushM $ SpiderIncremental . dynamicHold <$> Reflex.Spider.Internal.hold v0 e
   {-# INLINABLE headE #-}
-  headE = R.slowHeadE
---  headE (SpiderEvent e) = SpiderPushM $ SpiderEvent <$> Reflex.Spider.Internal.headE e
+  headE (SpiderEvent e) = SpiderPushM $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderPushM nowSpiderEventM
   {-# INLINABLE liftPushM #-}
@@ -2614,8 +2611,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 e = SpiderHostFrame $ fmap (SpiderIncremental . dynamicHold) $ Reflex.Spider.Internal.hold v0 $ unSpiderEvent e
   {-# INLINABLE headE #-}
-  headE = R.slowHeadE
---  headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e
+  headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderHostFrame Reflex.Class.now
   {-# INLINABLE liftPushM #-}

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -812,12 +812,12 @@ globalSpiderTimelineEnv = unsafePerformIO unsafeNewSpiderTimelineEnv
 
 -- | Stores all global data relevant to a particular Spider timeline; only one
 -- value should exist for each type @x@
-newtype SpiderTimelineEnv x = STE {unSTE :: SpiderTimelineEnv' x}
+newtype SpiderTimelineEnv (x :: Type) = STE {unSTE :: SpiderTimelineEnv' x}
 -- We implement SpiderTimelineEnv with a newtype wrapper so
 -- we can get the coercions we want safely.
 type role SpiderTimelineEnv nominal
 
-data SpiderTimelineEnv' x = SpiderTimelineEnv
+data SpiderTimelineEnv' (x :: Type) = SpiderTimelineEnv
   { _spiderTimeline_lock :: {-# UNPACK #-} !(MVar ())
   , _spiderTimeline_eventEnv :: {-# UNPACK #-} !(EventEnv x)
 #ifdef DEBUG
@@ -837,7 +837,7 @@ instance GEq SpiderTimelineEnv where
 data EventEnv x
    = EventEnv { eventEnvAssignments :: !(IORef [SomeAssignment x]) -- Needed for Subscribe
               , eventEnvHoldInits :: !(IORef [SomeHoldInit x]) -- Needed for Subscribe
-              , eventEnvDynInits :: !(IORef [SomeDynInit x])
+              , eventEnvSamplesToForce :: !(IORef [SomeThunk]) -- Deferred forces from lazy sampling
               , eventEnvMergeUpdates :: !(IORef [SomeMergeUpdate x])
               , eventEnvMergeInits :: !(IORef [SomeMergeInit x]) -- Needed for Subscribe
               , eventEnvClears :: !(IORef [Some Clear]) -- Needed for Subscribe
@@ -872,10 +872,6 @@ instance HasSpiderTimeline x => Defer (SomeHoldInit x) (EventM x) where
   {-# INLINE getDeferralQueue #-}
   getDeferralQueue = asksEventEnv eventEnvHoldInits
 
-instance HasSpiderTimeline x => Defer (SomeDynInit x) (EventM x) where
-  {-# INLINE getDeferralQueue #-}
-  getDeferralQueue = asksEventEnv eventEnvDynInits
-
 instance Defer (SomeHoldInit x) (BehaviorM x) where
   {-# INLINE getDeferralQueue #-}
   getDeferralQueue = BehaviorM $ asks snd
@@ -887,6 +883,14 @@ instance HasSpiderTimeline x => Defer (SomeMergeUpdate x) (EventM x) where
 instance HasSpiderTimeline x => Defer (SomeMergeInit x) (EventM x) where
   {-# INLINE getDeferralQueue #-}
   getDeferralQueue = asksEventEnv eventEnvMergeInits
+
+instance HasSpiderTimeline x => Defer SomeThunk (EventM x) where
+  {-# INLINE getDeferralQueue #-}
+  getDeferralQueue = asksEventEnv eventEnvSamplesToForce
+
+{-# INLINE enqueueForce #-}
+enqueueForce :: HasSpiderTimeline x => a -> EventM x ()
+enqueueForce a = defer (SomeThunk a)
 
 class HasSpiderTimeline x => HasCurrentHeight x m | m -> x where
   getCurrentHeight :: m Height
@@ -902,7 +906,7 @@ instance HasSpiderTimeline x => HasCurrentHeight x (EventM x) where
     delayedRef <- asksEventEnv eventEnvDelayedMerges
     liftIO $ modifyIORef' delayedRef $ IntMap.insertWith (++) (unHeight height) [subscribed]
 
-class HasSpiderTimeline x where
+class HasSpiderTimeline (x :: Type) where
   -- | Retrieve the current SpiderTimelineEnv
   spiderTimeline :: SpiderTimelineEnv x
 
@@ -1050,7 +1054,9 @@ data Root x k
 
 data SomeHoldInit x = forall p. Patch p => SomeHoldInit !(Hold x p)
 
-data SomeDynInit x = forall p. Patch p => SomeDynInit !(Dyn x p)
+-- | An unevaluated lazy 'sample' which needs to be forced in the current frame to
+-- ensure the current value is read instead of some future one.
+data SomeThunk = forall a. SomeThunk a
 
 data SomeMergeUpdate x = SomeMergeUpdate
   { _someMergeUpdate_update :: !(EventM x [EventSubscription x])
@@ -1210,7 +1216,6 @@ instance HasSpiderTimeline x => Zip (Event x) where
 #endif
 
 data DynType x p = UnsafeDyn !(BehaviorM x (PatchTarget p), Event x p)
-                 | BuildDyn  !(EventM x (PatchTarget p), Event x p)
                  | HoldDyn   !(Hold x p)
 
 newtype Dyn (x :: Type) p = Dyn { unDyn :: IORef (DynType x p) }
@@ -1233,13 +1238,6 @@ zipDynWith f da db =
           These (Identity a) (Identity b) -> return (a, b)
         return $ Just $ Identity $ f a b
   in dynamicDynIdentity $ unsafeBuildDynamic (f <$> readBehaviorUntracked (dynamicCurrent da) <*> readBehaviorUntracked (dynamicCurrent db)) ec
-
-buildDynamic :: (Defer (SomeDynInit x) m, Patch p) => EventM x (PatchTarget p) -> Event x p -> m (Dyn x p)
-buildDynamic readV0 v' = do
-  result <- liftIO $ newIORef $ BuildDyn (readV0, v')
-  let !d = Dyn result
-  defer $ SomeDynInit d
-  return d
 
 unsafeBuildDynamic :: BehaviorM x (PatchTarget p) -> Event x p -> Dyn x p
 unsafeBuildDynamic readV0 v' =
@@ -1548,12 +1546,6 @@ getDynHold d = do
     UnsafeDyn (readV0, v') -> do
       holdInits <- getDeferralQueue
       v0 <- liftIO $ runBehaviorM readV0 Nothing holdInits
-      hold' v0 v'
-    BuildDyn (readV0, v') -> do
-      v0 <- liftIO $ runEventM readV0
-      hold' v0 v'
-  where
-    hold' v0 v' = do
       h <- hold v0 v'
       liftIO $ writeIORef (unDyn d) $ HoldDyn h
       return h
@@ -2291,31 +2283,33 @@ fanG e = unsafePerformIO $ do
         }
   pure $ EventSelectorG $ \k -> eventFan k f
 
-runHoldInits :: HasSpiderTimeline x => IORef [SomeHoldInit x] -> IORef [SomeDynInit x] -> IORef [SomeMergeInit x] -> EventM x ()
-runHoldInits holdInitRef dynInitRef mergeInitRef = do
+-- | Process all pending hold inits, merge inits, and lazy-sample forces in a
+-- single loop. The three queues are interleaved because each can produce items
+-- for the others: hold-init subscription can enqueue lazy-sample forces (via
+-- pushCheap firing on a current occurrence), and forcing a lazy sample can
+-- enqueue new hold inits (via runBehaviorM appending to the holdInits ref).
+runHoldInits :: HasSpiderTimeline x => IORef [SomeHoldInit x] -> IORef [SomeMergeInit x] -> IORef [SomeThunk] -> EventM x ()
+runHoldInits holdInitRef mergeInitRef samplesToForceRef = do
   holdInits <- liftIO $ readIORef holdInitRef
-  dynInits <- liftIO $ readIORef dynInitRef
   mergeInits <- liftIO $ readIORef mergeInitRef
-  unless (null holdInits && null dynInits && null mergeInits) $ do
+  forces <- liftIO $ readIORef samplesToForceRef
+  unless (null holdInits && null mergeInits && null forces) $ do
     liftIO $ writeIORef holdInitRef []
-    liftIO $ writeIORef dynInitRef []
     liftIO $ writeIORef mergeInitRef []
+    liftIO $ writeIORef samplesToForceRef []
     mapM_ initHold holdInits
-    mapM_ initDyn dynInits
     mapM_ unSomeMergeInit mergeInits
-    runHoldInits holdInitRef dynInitRef mergeInitRef
+    liftIO $ mapM_ (\(SomeThunk a) -> void $ evaluate a) forces
+    runHoldInits holdInitRef mergeInitRef samplesToForceRef
 
 initHold :: HasSpiderTimeline x => SomeHoldInit x -> EventM x ()
 initHold (SomeHoldInit h) = void $ getHoldEventSubscription h
-
-initDyn :: HasSpiderTimeline x => SomeDynInit x -> EventM x ()
-initDyn (SomeDynInit d) = void $ getDynHold d
 
 newEventEnv :: IO (EventEnv x)
 newEventEnv = do
   toAssignRef <- newIORef [] -- This should only actually get used when events are firing
   holdInitRef <- newIORef []
-  dynInitRef <- newIORef []
+  samplesToForceRef <- newIORef []
   mergeUpdateRef <- newIORef []
   mergeInitRef <- newIORef []
   heightRef <- newIORef zeroHeight
@@ -2324,13 +2318,13 @@ newEventEnv = do
   toClearRootRef <- newIORef []
   coincidenceInfosRef <- newIORef []
   delayedRef <- newIORef IntMap.empty
-  return $ EventEnv toAssignRef holdInitRef dynInitRef mergeUpdateRef mergeInitRef toClearRef toClearIntRef toClearRootRef heightRef coincidenceInfosRef delayedRef
+  return $ EventEnv toAssignRef holdInitRef samplesToForceRef mergeUpdateRef mergeInitRef toClearRef toClearIntRef toClearRootRef heightRef coincidenceInfosRef delayedRef
 
 clearEventEnv :: EventEnv x -> IO ()
-clearEventEnv (EventEnv toAssignRef holdInitRef dynInitRef mergeUpdateRef mergeInitRef toClearRef toClearIntRef toClearRootRef heightRef coincidenceInfosRef delayedRef) = do
+clearEventEnv (EventEnv toAssignRef holdInitRef samplesToForceRef mergeUpdateRef mergeInitRef toClearRef toClearIntRef toClearRootRef heightRef coincidenceInfosRef delayedRef) = do
   writeIORef toAssignRef []
   writeIORef holdInitRef []
-  writeIORef dynInitRef []
+  writeIORef samplesToForceRef []
   writeIORef mergeUpdateRef []
   writeIORef mergeInitRef []
   writeIORef heightRef zeroHeight
@@ -2346,7 +2340,7 @@ runFrame a = SpiderHost $ do
   let env = _spiderTimeline_eventEnv $ unSTE (spiderTimeline :: SpiderTimelineEnv x)
   let go = do
         result <- a
-        runHoldInits (eventEnvHoldInits env) (eventEnvDynInits env) (eventEnvMergeInits env) -- This must happen before doing the assignments, in case subscribing a Hold causes existing Holds to be read by the newly-propagated events
+        runHoldInits (eventEnvHoldInits env) (eventEnvMergeInits env) (eventEnvSamplesToForce env)
         return result
   result <- runEventM go
   toClear <- readIORef $ eventEnvClears env
@@ -2380,7 +2374,7 @@ runFrame a = SpiderHost $ do
     writeIORef (switchSubscribedBehaviorParents subscribed) []
     writeIORef (eventEnvHoldInits env) [] --TODO: Should we reuse this?
     e <- runBehaviorM (readBehaviorTracked (switchSubscribedParent subscribed)) (Just (wi', switchSubscribedBehaviorParents subscribed)) $ eventEnvHoldInits env
-    runEventM $ runHoldInits (eventEnvHoldInits env) (eventEnvDynInits env) (eventEnvMergeInits env) --TODO: Is this actually OK? It seems like it should be, since we know that no events are firing at this point, but it still seems inelegant
+    runEventM $ runHoldInits (eventEnvHoldInits env) (eventEnvMergeInits env) (eventEnvSamplesToForce env) --TODO: Is this actually OK? It seems like it should be, since we know that no events are firing at this point, but it still seems inelegant
     --TODO: Make sure we touch the pieces of the SwitchSubscribed at the appropriate times
     sub <- newSubscriberSwitch subscribed
     subscription <- unSpiderHost $ runFrame $ {-# SCC "subscribeSwitch" #-} subscribe e sub --TODO: Assert that the event isn't firing --TODO: This should not loop because none of the events should be firing, but still, it is inefficient
@@ -2499,7 +2493,7 @@ invalidate toReconnectRef wis = do
 --------------------------------------------------------------------------------
 
 -- | Designates the default, global Spider timeline
-data SpiderTimeline x
+data SpiderTimeline (x :: Type)
 type role SpiderTimeline nominal
 
 -- | The default, global Spider environment
@@ -2507,7 +2501,11 @@ type Spider = SpiderTimeline Global
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (EventM x) where
   {-# INLINABLE sample #-}
-  sample (SpiderBehavior b) = readBehaviorUntracked b
+  sample (SpiderBehavior b) = do
+    holdInits <- getDeferralQueue
+    res <- liftIO . unsafeInterleaveIO $ runBehaviorM (readBehaviorTracked b) Nothing holdInits
+    enqueueForce res
+    return res
 
 instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (EventM x) where
   {-# INLINABLE hold #-}
@@ -2517,7 +2515,9 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Event
   {-# INLINABLE holdIncremental #-}
   holdIncremental = holdIncrementalSpiderEventM
   {-# INLINABLE buildDynamic #-}
-  buildDynamic = buildDynamicSpiderEventM
+  buildDynamic (SpiderPushM getV0) e = do
+    v0 <- getV0
+    R.holdDyn v0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderEvent <$> Reflex.Spider.Internal.headE e
@@ -2530,7 +2530,7 @@ instance Reflex.Class.MonadSample (SpiderTimeline x) (SpiderPullM x) where
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderPushM x) where
   {-# INLINABLE sample #-}
-  sample (SpiderBehavior b) = SpiderPushM $ readBehaviorUntracked b
+  sample b = SpiderPushM $ Reflex.Class.sample b
 
 instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (SpiderPushM x) where
   {-# INLINABLE hold #-}
@@ -2540,7 +2540,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 (SpiderEvent e) = SpiderPushM $ SpiderIncremental . dynamicHold <$> Reflex.Spider.Internal.hold v0 e
   {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 (SpiderEvent e) = SpiderPushM $ fmap (SpiderDynamic . dynamicDynIdentity) $ Reflex.Spider.Internal.buildDynamic (coerce getV0) $ coerce e
+  buildDynamic getV0 e = SpiderPushM $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderPushM $ SpiderEvent <$> Reflex.Spider.Internal.headE e
@@ -2590,9 +2590,6 @@ holdDynSpiderEventM v0 e = fmap (SpiderDynamic . dynamicHoldIdentity) $ Reflex.S
 holdIncrementalSpiderEventM :: (HasSpiderTimeline x, Patch p) => PatchTarget p -> Reflex.Class.Event (SpiderTimeline x) p -> EventM x (Reflex.Class.Incremental (SpiderTimeline x) p)
 holdIncrementalSpiderEventM v0 e = fmap (SpiderIncremental . dynamicHold) $ Reflex.Spider.Internal.hold v0 $ unSpiderEvent e
 
-buildDynamicSpiderEventM :: HasSpiderTimeline x => SpiderPushM x a -> Reflex.Class.Event (SpiderTimeline x) a -> EventM x (Reflex.Class.Dynamic (SpiderTimeline x) a)
-buildDynamicSpiderEventM getV0 e = fmap (SpiderDynamic . dynamicDynIdentity) $ Reflex.Spider.Internal.buildDynamic (coerce getV0) $ coerce $ unSpiderEvent e
-
 instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (SpiderHost x) where
   {-# INLINABLE hold #-}
   hold v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.hold v0 e
@@ -2609,7 +2606,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
 
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHostFrame x) where
-  sample = SpiderHostFrame . readBehaviorUntracked . unSpiderBehavior --TODO: This can cause problems with laziness, so we should get rid of it if we can
+  sample b = SpiderHostFrame $ Reflex.Class.sample b
 
 instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (SpiderHostFrame x) where
   {-# INLINABLE hold #-}
@@ -2619,7 +2616,7 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 e = SpiderHostFrame $ fmap (SpiderIncremental . dynamicHold) $ Reflex.Spider.Internal.hold v0 $ unSpiderEvent e
   {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = SpiderHostFrame $ fmap (SpiderDynamic . dynamicDynIdentity) $ Reflex.Spider.Internal.buildDynamic (coerce getV0) $ coerce $ unSpiderEvent e
+  buildDynamic getV0 e = SpiderHostFrame $ Reflex.Class.buildDynamic getV0 e
   {-# INLINABLE headE #-}
   headE = R.slowHeadE
 --  headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e

--- a/src/Reflex/TriggerEvent/Base.hs
+++ b/src/Reflex/TriggerEvent/Base.hs
@@ -127,12 +127,12 @@ instance MonadHold t m => MonadHold t (TriggerEventT t m) where
   holdDyn v0 v' = lift $ holdDyn v0 v'
   {-# INLINABLE holdIncremental #-}
   holdIncremental v0 v' = lift $ holdIncremental v0 v'
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic a0 = lift . buildDynamic a0
   {-# INLINABLE headE #-}
   headE = lift . headE
   {-# INLINABLE now #-}
   now = lift now
+  {-# INLINABLE liftPushM #-}
+  liftPushM = lift . liftPushM
 
 instance Adjustable t m => Adjustable t (TriggerEventT t m) where
   {-# INLINABLE runWithReplace #-}

--- a/test/Reflex/Plan/Pure.hs
+++ b/test/Reflex/Plan/Pure.hs
@@ -39,9 +39,9 @@ instance MonadHold (Pure Int) PurePlan where
   hold initial  = liftPlan . hold initial
   holdDyn initial = liftPlan . holdDyn initial
   holdIncremental initial = liftPlan . holdIncremental initial
-  buildDynamic getInitial = liftPlan . buildDynamic getInitial
   headE = liftPlan . headE
   now = liftPlan now
+  liftPushM = liftPlan . liftPushM
 
 instance MonadSample (Pure Int) PurePlan where
   sample = liftPlan . sample

--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -330,6 +330,20 @@ testCases =
       let e = pushAlways (\a -> if a == "a" then now else return never) e1
       x <- accumDyn (<>) never e 
       return . coincidence $ updated x
+  , testB "sampling-monadfix" $ do
+      rec
+        x <- sample b
+        b <- hold "0" never
+      _ <- sample b
+      return (x <$ b)
+  , testB "sampling-monadfix-twice-removed" $ do
+      rec
+        e1 <- events1
+        x <- sample b
+        b' <- hold x e1
+        b <- hold "0" e1
+      _ <- sample b'
+      return b'
   ] where
 
     events1, events2, events3 ::  TestPlan t m => m (Event t String)


### PR DESCRIPTION
Reflex currently requires us to predict whether sampling the "now" value of a behavior operationally precedes the creation of the behavior in `MonadFix` instances. This makes it hard to implement high-level abstractions on top of Reflex. For example, a combination of `DynamicWriter` and a `Reader` of the result can lead to users running into mysterious "cycles in fixIO" errors just by changing the order of innocuous looking expressions in `MonadFix`. To keep laziness the library implementer would have to add `buildDynamic` style versions of their primitives, and teach the user how to use these.

This MR solves this issue and makes it so that `sample` in `Spider` matches the `Pure` semantics in `MonadFix`. This is achieved using `unsafeInterleaveIO` on the `IORef` read. The sampled values are forced to WHNF before event propagation to prevent incorrect results. If the values were left unforced the `IORef` might contain a future value instead of the one at the logical time of the `sample`:

```diff
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (EventM x) where
   {-# INLINABLE sample #-}
-  sample (SpiderBehavior b) = readBehaviorUntracked b
+  sample (SpiderBehavior b) = do
+    holdInits <- getDeferralQueue
+    res <- liftIO . unsafeInterleaveIO $ runBehaviorM (readBehaviorTracked b) Nothing holdInits
+    enqueueForce res
+    return res
```

The MR contains two commits. The first implements lazy sampling without adjusting the `MonadHold` class, while the second follows up and removes the no longer needed `buildDynamic` class member. To keep `buildDynamic` implementable, I've added a new function to `MonadHold` called `liftPushM`.

I was hoping the defaults would avoid a breaking change, but unfortunately the extra `Reflex t` constraint on the default implementation breaks downstream after all:

```haskell
class MonadSample t m => MonadHold t m where
  ...
  -- | DEPRECATED. This function allowed for extra laziness when sampling
  -- behaviors, but is no longer needed. When implementing MonadHold use the new
  -- 'liftPushM' instead.
  buildDynamic :: PushM t a -> Event t a -> m (Dynamic t a)
  buildDynamic initialValue e = do
    iv <- liftPushM initialValue
    holdDyn iv e
  {-# INLINABLE liftPushM #-}
  liftPushM :: PushM t a -> m a
  default liftPushM :: (Reflex t) => PushM t a -> m a
  liftPushM m = sample . current =<< buildDynamic m never
```

## Performance implications

If I'm interpreting things correctly the benchmarks didn't show any performance degradation, and running reflex-todomvc looks normal as well.