### PR TITLE
Amortized invalidator-list pruning with doubling threshold

### DIFF
--- a/bench/RunAll.hs
+++ b/bench/RunAll.hs
@@ -121,6 +121,7 @@ benchmarks = implGroup "spider" runSpiderHost cases
     firing n     = group ("firing "    <> show n) $ Focused.firing n
     merging n    = group ("merging "   <> show n) $ Focused.merging n
     dynamics n   = group ("dynamics "  <> show n) $ Focused.dynamics n
+    shared w     = group ("sharedInvalidators " <> show w) $ Focused.sharedInvalidators w
     cases = concat
       [ sub 100 40
       , dynamics 100
@@ -131,6 +132,10 @@ benchmarks = implGroup "spider" runSpiderHost cases
       , merging 50
       , merging 100
       , merging 200
+      , shared 30
+      , shared 100
+      , shared 300
+      , shared 1000
       ]
 
 pattern RunTestCaseFlag = "--run-test-case"

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -709,7 +709,7 @@ behaviorPull !p = Behavior $ do
     case val of
       Just subscribed -> do
         askParentsRef >>= mapM_ (\r -> liftIO $ modifyIORef' r (SomeBehaviorSubscribed (Some (BehaviorSubscribedPull subscribed)) :))
-        askInvalidator >>= mapM_ (\wi -> liftIO $ modifyIORef' (pullSubscribedInvalidators subscribed) (wi:))
+        askInvalidator >>= mapM_ (liftIO . addInvalidatorAmortized (pullSubscribedInvalidators subscribed))
         liftIO $ touch $ pullSubscribedOwnInvalidator subscribed
         return $ pullSubscribedValue subscribed
       Nothing -> do
@@ -718,7 +718,8 @@ behaviorPull !p = Behavior $ do
         parentsRef <- liftIO $ newIORef []
         holdInits <- askBehaviorHoldInits
         a <- liftIO $ runReaderIO (unBehaviorM $ pullCompute p) (Just (wi, parentsRef), holdInits)
-        invsRef <- liftIO . newIORef . maybeToList =<< askInvalidator
+        inv0 <- maybeToList <$> askInvalidator
+        invsRef <- liftIO $ newIORef $ InvalidatorList (length inv0) invalidatorPruneThreshold inv0
         parents <- liftIO $ readIORef parentsRef
         let subscribed = PullSubscribed
               { pullSubscribedValue = a
@@ -737,10 +738,48 @@ behaviorDyn !d = Behavior $ readHoldTracked =<< getDynHold d
 readHoldTracked :: Hold x p -> BehaviorM x (PatchTarget p)
 readHoldTracked h = do
   result <- liftIO $ readIORef $ holdValue h
-  askInvalidator >>= mapM_ (\wi -> liftIO $ modifyIORef' (holdInvalidators h) (wi:))
+  askInvalidator >>= mapM_ (liftIO . addInvalidatorAmortized (holdInvalidators h))
   askParentsRef >>= mapM_ (\r -> liftIO $ modifyIORef' r (SomeBehaviorSubscribed (Some (BehaviorSubscribedHold h)) :))
   liftIO $ touch h -- Otherwise, if this gets inlined enough, the hold's parent reference may get collected
   return result
+
+data InvalidatorList x = InvalidatorList
+  { invalidatorListSize :: !Int
+  , invalidatorListPruneAt :: !Int
+  , invalidatorListElems :: ![Weak (Invalidator x)]
+  }
+
+emptyInvalidatorList :: InvalidatorList x
+emptyInvalidatorList = InvalidatorList
+  { invalidatorListSize = 0
+  , invalidatorListPruneAt = invalidatorPruneThreshold
+  , invalidatorListElems = []
+  }
+
+-- | Add invalidator weak ref to invalidator list, pruning finalized entries
+-- once the list grows to its "prune at" size.
+{-# INLINE addInvalidatorAmortized #-}
+addInvalidatorAmortized :: IORef (InvalidatorList x) -> Weak (Invalidator x) -> IO ()
+addInvalidatorAmortized ref weakInvalidator = do
+  InvalidatorList listSize pruneAt weakInvalidators <- readIORef ref
+  if listSize < pruneAt
+    then writeIORef ref $! InvalidatorList (listSize + 1) pruneAt (weakInvalidator : weakInvalidators)
+    else do
+      (liveCount, liveInvalidators) <-
+        foldrM
+        (\weakInvalidator' (!liveCount, liveInvalidators) ->
+            (\case Just _ -> (liveCount + 1, weakInvalidator' : liveInvalidators)
+                   Nothing -> (liveCount, liveInvalidators))
+            <$> deRefWeak weakInvalidator')
+        (0, [])
+        weakInvalidators
+      writeIORef ref $! InvalidatorList
+        (liveCount + 1)
+        (max invalidatorPruneThreshold (2 * liveCount))
+        (weakInvalidator : liveInvalidators)
+
+invalidatorPruneThreshold :: Int
+invalidatorPruneThreshold = 100
 
 {-# INLINABLE readBehaviorUntracked #-}
 readBehaviorUntracked :: Defer (SomeHoldInit x) m => Behavior x a -> m a
@@ -795,7 +834,7 @@ dynamicDynIdentity = dynamicDyn
 --type role Hold representational
 data Hold x p
    = Hold { holdValue :: !(IORef (PatchTarget p))
-          , holdInvalidators :: !(IORef [Weak (Invalidator x)])
+          , holdInvalidators :: !(IORef (InvalidatorList x))
           , holdEvent :: Event x p -- This must be lazy, or holds cannot be defined before their input Events
           , holdParent :: !(IORef (Maybe (EventSubscription x))) -- Keeps its parent alive (will be undefined until the hold is initialized) --TODO: Probably shouldn't be an IORef
 #ifdef DEBUG_NODEIDS
@@ -948,7 +987,7 @@ instance HasSpiderTimeline x => Defer (SomeResetCoincidence x) (EventM x) where
 hold :: (Patch p, Defer (SomeHoldInit x) m) => PatchTarget p -> Event x p -> m (Hold x p)
 hold v0 e = do
   valRef <- liftIO $ newIORef v0
-  invsRef <- liftIO $ newIORef []
+  invsRef <- liftIO $ newIORef emptyInvalidatorList
   parentRef <- liftIO $ newIORef Nothing
 #ifdef DEBUG_NODEIDS
   nodeId <- liftIO newNodeId
@@ -1013,7 +1052,7 @@ newtype SomeBehaviorSubscribed x = SomeBehaviorSubscribed (Some (BehaviorSubscri
 --type role PullSubscribed representational
 data PullSubscribed x a
    = PullSubscribed { pullSubscribedValue :: !a
-                    , pullSubscribedInvalidators :: !(IORef [Weak (Invalidator x)])
+                    , pullSubscribedInvalidators :: !(IORef (InvalidatorList x))
                     , pullSubscribedOwnInvalidator :: !(Invalidator x)
                     , pullSubscribedParents :: ![SomeBehaviorSubscribed x] -- Need to keep parent behaviors alive, or they won't let us know when they're invalidated
                     }
@@ -1340,7 +1379,7 @@ newtype IntClear a = IntClear (IORef (IntMap a))
 
 newtype RootClear k = RootClear (IORef (DMap k Identity))
 
-data SomeAssignment x = forall a. SomeAssignment {-# UNPACK #-} !(IORef a) {-# UNPACK #-} !(IORef [Weak (Invalidator x)]) a
+data SomeAssignment x = forall a. SomeAssignment {-# UNPACK #-} !(IORef a) {-# UNPACK #-} !(IORef (InvalidatorList x)) a
 
 debugFinalize :: Bool
 debugFinalize = False
@@ -1352,8 +1391,6 @@ mkWeakPtrWithDebug x debugNote = do
     if debugFinalize
     then Just $ debugStrLn $ "finalizing: " ++ debugNote
     else Nothing
-
-type WeakList a = [Weak a]
 
 type CanTrace x m = (HasSpiderTimeline x, MonadIO m)
 
@@ -1503,8 +1540,8 @@ instance Show EventLoopException where
 propagateSubscriberHold :: forall x p. (HasSpiderTimeline x, Patch p) => Hold x p -> p -> EventM x ()
 propagateSubscriberHold h a = do
   {-# SCC "trace" #-} when debugPropagate $ traceM (Proxy :: Proxy x) $ liftIO $ do
-    invalidators <- liftIO $ readIORef $ holdInvalidators h
-    return $ "SubscriberHold" <> showNodeId h <> ": " ++ show (length invalidators)
+    InvalidatorList n _ _ <- liftIO $ readIORef $ holdInvalidators h
+    return $ "SubscriberHold" <> showNodeId h <> ": " ++ show n
 
   v <- {-# SCC "read" #-} liftIO $ readIORef $ holdValue h
   case {-# SCC "apply" #-} apply a v of
@@ -2479,8 +2516,8 @@ calculateCoincidenceHeight subscribed = do
 
 data SomeSwitchSubscribed x = forall a. SomeSwitchSubscribed {-# NOUNPACK #-} (SwitchSubscribed x a)
 
-invalidate :: IORef [SomeSwitchSubscribed x] -> WeakList (Invalidator x) -> IO (WeakList (Invalidator x))
-invalidate toReconnectRef wis = do
+invalidate :: IORef [SomeSwitchSubscribed x] -> InvalidatorList x -> IO (InvalidatorList x)
+invalidate toReconnectRef (InvalidatorList _ _ wis) = do
   forM_ wis $ \wi -> do
     mi <- deRefWeak wi
     case mi of
@@ -2499,7 +2536,7 @@ invalidate toReconnectRef wis = do
           InvalidatorSwitch subscribed -> do
             traceInvalidate $ "invalidate: Switch" <> showNodeId subscribed
             modifyIORef' toReconnectRef (SomeSwitchSubscribed subscribed :)
-  return [] -- Since we always finalize everything, always return an empty list --TODO: There are some things that will need to be re-subscribed every time; we should try to avoid finalizing them
+  return emptyInvalidatorList -- Since we always finalize everything, always return an empty list --TODO: There are some things that will need to be re-subscribed every time; we should try to avoid finalizing them
 
 --------------------------------------------------------------------------------
 -- Reflex integration

--- a/test/Reflex/Bench/Focused.hs
+++ b/test/Reflex/Bench/Focused.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Reflex.Bench.Focused where
 
@@ -376,6 +377,12 @@ firing n =
       counters = countMany =<< sparse
 
 
-
-
-
+-- Stress-test sampling a single behavior through a large, shared set of pulls,
+-- exercising the invalidator-list pruning path.
+sharedInvalidators :: Word -> [(String, TestCase)]
+sharedInvalidators width =
+  [ testB "sumPulls" $ do
+      b <- current <$> (count @_ @_ @Int =<< events 10)
+      let ps = [ (+ fromIntegral i) <$> b | i <- [1 .. width] ]
+      return $ pull $ sum <$> traverse sample ps
+  ]

--- a/test/behaviorLeak.hs
+++ b/test/behaviorLeak.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Test whether Applicative combination of Behaviors leaks memory when one of
--- the Behaviors' source events doesn't update.
+-- the Behaviors' source events never occurs.
 -- (https://github.com/reflex-frp/reflex/issues/490)
 
 import Control.Monad
@@ -20,9 +20,16 @@ import System.Exit
 import System.Mem (performMajorGC)
 import Text.Printf
 
-warmupN, measureN :: Int
-warmupN  = 200000
-measureN = 2000000
+warmupTicks :: Int
+warmupTicks = 200000
+windowTicks :: Int
+windowTicks = 200000
+samplesPerWindow :: Int
+samplesPerWindow = 20
+ticksBetweenWindows :: Int
+ticksBetweenWindows = 9 * windowTicks
+allowedGrowthBytes :: Integer
+allowedGrowthBytes = 512 * 1024
 
 testCase :: (Reflex t, MonadHold t m) => Event t b -> m (Behavior t (Int, Int))
 testCase tickE = do
@@ -44,24 +51,29 @@ main = do
     let fireOnce = void $ fireEventsAndRead [trigger :=> Identity ()] $ do
           v <- sample b
           v `seq` pure ()
-    let liveBytes = liftIO $ do
+        liveBytes = liftIO $ do
           performMajorGC
-          gcdetails_live_bytes . gc <$> getRTSStats
-    replicateM_ warmupN fireOnce
-    liftIO performMajorGC
-    before <- liveBytes
-    replicateM_ measureN fireOnce
-    after <- liveBytes
+          fromIntegral . gcdetails_live_bytes . gc <$> getRTSStats :: IO Integer
+        measureWindow = do
+          let chunk = windowTicks `div` samplesPerWindow
+          samples <- replicateM samplesPerWindow $ do
+            replicateM_ chunk fireOnce
+            liveBytes
+          pure $ sum samples `div` fromIntegral samplesPerWindow
+
+    replicateM_ warmupTicks fireOnce
+    firstWindowAvg <- measureWindow
+    replicateM_ ticksBetweenWindows fireOnce
+    secondWindowAvg <- measureWindow
     liftIO $ touch b
     liftIO $ do
-      let liveBytesDifference = after - before
-      let liveBytesRatio :: Double =
-            fromIntegral (toInteger after - toInteger before)
-            / fromIntegral (measureN - warmupN)
-      if liveBytesRatio < 0.1
+      let growth = secondWindowAvg - firstWindowAvg
+      if growth <= allowedGrowthBytes
         then putStrLn "Succeeded"
         else do
           printf "Failed: Behavior Applicative space leak\n"
-          printf "    absolute difference: %d live bytes\n" liveBytesDifference
-          printf "    approx. avg. leaked bytes per tick: %.3f\n" liveBytesRatio
-          -- exitFailure -- Ignore until fixed.
+          printf "    first-window avg live bytes:  %d\n" firstWindowAvg
+          printf "    second-window avg live bytes: %d\n" secondWindowAvg
+          printf "    growth over %d intervening ticks: %d bytes (allowed %d)\n"
+            ticksBetweenWindows growth allowedGrowthBytes
+          exitFailure


### PR DESCRIPTION
Fixes #490, enables the `behaviorLeak` test, adds a benchmark for large invalidator lists.