### PR TITLE
Use specialized int-based instead of generic merge

### DIFF
--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -956,6 +956,7 @@ mergeMap :: (Reflex t, Ord k) => Map k (Event t a) -> Event t (Map k a)
 mergeMap = fmap dmapToMap . merge . mapWithFunctorToDMap
 
 -- | Alias for 'mergeInt'.
+{-# DEPRECATED mergeIntMap "Use 'mergeInt' instead" #-}
 mergeIntMap :: Reflex t => IntMap (Event t a) -> Event t (IntMap a)
 mergeIntMap = mergeInt
 
@@ -964,6 +965,7 @@ mergeMapIncremental :: (Reflex t, Ord k) => Incremental t (PatchMap k (Event t a
 mergeMapIncremental = fmap dmapToMap . mergeIncremental . unsafeMapIncremental mapWithFunctorToDMap (const2PatchDMapWith id)
 
 -- | Alias for 'mergeIntIncremental'.
+{-# DEPRECATED mergeIntMapIncremental "Use 'mergeIntIncremental' instead" #-}
 mergeIntMapIncremental :: Reflex t => Incremental t (PatchIntMap (Event t a)) -> Event t (IntMap a)
 mergeIntMapIncremental = mergeIntIncremental
 

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -955,19 +955,19 @@ unsafeMapIncremental f g a = unsafeBuildIncremental (fmap f $ sample $ currentIn
 mergeMap :: (Reflex t, Ord k) => Map k (Event t a) -> Event t (Map k a)
 mergeMap = fmap dmapToMap . merge . mapWithFunctorToDMap
 
--- | Like 'mergeMap' but for 'IntMap'.
+-- | Alias for 'mergeInt'.
 mergeIntMap :: Reflex t => IntMap (Event t a) -> Event t (IntMap a)
-mergeIntMap = fmap dmapToIntMap . merge . intMapWithFunctorToDMap
+mergeIntMap = mergeInt
 
--- | Create a merge whose parents can change over time
+-- | Create a merge whose parents can change over time.
 mergeMapIncremental :: (Reflex t, Ord k) => Incremental t (PatchMap k (Event t a)) -> Event t (Map k a)
 mergeMapIncremental = fmap dmapToMap . mergeIncremental . unsafeMapIncremental mapWithFunctorToDMap (const2PatchDMapWith id)
 
--- | Create a merge whose parents can change over time
+-- | Alias for 'mergeIntIncremental'.
 mergeIntMapIncremental :: Reflex t => Incremental t (PatchIntMap (Event t a)) -> Event t (IntMap a)
-mergeIntMapIncremental = fmap dmapToIntMap . mergeIncremental . unsafeMapIncremental intMapWithFunctorToDMap (const2IntPatchDMapWith id)
+mergeIntMapIncremental = mergeIntIncremental
 
--- | Experimental: Create a merge whose parents can change over time; changing the key of an Event is more efficient than with mergeIncremental
+-- | Experimental: Create a merge whose parents can change over time; changing the key of an Event is more efficient than with mergeIncremental.
 mergeMapIncrementalWithMove :: (Reflex t, Ord k) => Incremental t (PatchMapWithMove k (Event t a)) -> Event t (Map k a)
 mergeMapIncrementalWithMove = fmap dmapToMap . mergeIncrementalWithMove . unsafeMapIncremental mapWithFunctorToDMap (const2PatchDMapWithMoveWith id)
 

--- a/src/Reflex/DynamicWriter/Base.hs
+++ b/src/Reflex/DynamicWriter/Base.hs
@@ -65,9 +65,9 @@ mergeDynIncremental a = unsafeBuildIncremental (mapM (sample . current) =<< samp
   where changedValues = fmap (PatchMap . fmap Just) $ mergeMapIncremental $ mapIncrementalMapValues updated a
         addedAndRemovedValues = flip pushAlways (updatedIncremental a) $ \(PatchMap m) -> PatchMap <$> mapM (mapM (sample . current)) m
 
-mergeIntMapDynIncremental :: Reflex t => Incremental t (PatchIntMap (Dynamic t v)) -> Incremental t (PatchIntMap v)
-mergeIntMapDynIncremental a = unsafeBuildIncremental (mapM (sample . current) =<< sample (currentIncremental a)) $ addedAndRemovedValues <> changedValues
-  where changedValues = fmap (PatchIntMap . fmap Just) $ mergeIntMapIncremental $ mapIncrementalMapValues updated a
+mergeIntDynIncremental :: Reflex t => Incremental t (PatchIntMap (Dynamic t v)) -> Incremental t (PatchIntMap v)
+mergeIntDynIncremental a = unsafeBuildIncremental (mapM (sample . current) =<< sample (currentIncremental a)) $ addedAndRemovedValues <> changedValues
+  where changedValues = fmap (PatchIntMap . fmap Just) $ mergeIntIncremental $ mapIncrementalMapValues updated a
         addedAndRemovedValues = flip pushAlways (updatedIncremental a) $ \(PatchIntMap m) -> PatchIntMap <$> mapM (mapM (sample . current)) m
 
 mergeDynIncrementalWithMove :: forall t k v. (Reflex t, Ord k) => Incremental t (PatchMapWithMove k (Dynamic t v)) -> Incremental t (PatchMapWithMove k v)
@@ -172,7 +172,7 @@ instance (Adjustable t m, Monoid w, MonadHold t m, Reflex t) => Adjustable t (Dy
     (result0, result') <- lift $ runWithReplace (runDynamicWriterT a0) $ runDynamicWriterT <$> a'
     tellDyn . join =<< holdDyn (snd result0) (snd <$> result')
     return (fst result0, fst <$> result')
-  traverseIntMapWithKeyWithAdjust = traverseIntMapWithKeyWithAdjustImpl traverseIntMapWithKeyWithAdjust mergeIntMapDynIncremental
+  traverseIntMapWithKeyWithAdjust = traverseIntMapWithKeyWithAdjustImpl traverseIntMapWithKeyWithAdjust mergeIntDynIncremental
   traverseDMapWithKeyWithAdjust = traverseDMapWithKeyWithAdjustImpl traverseDMapWithKeyWithAdjust mapPatchDMap weakenPatchDMapWith mergeDynIncremental
   traverseDMapWithKeyWithAdjustWithMove = traverseDMapWithKeyWithAdjustImpl traverseDMapWithKeyWithAdjustWithMove mapPatchDMapWithMove weakenPatchDMapWithMoveWith mergeDynIncrementalWithMove
 


### PR DESCRIPTION
Fix stray mergeG-based implementations of IntMap merging; we have a more efficient mergeInt* family of functions. This should make DynamicWriter slightly more efficient.