### PR TITLE
IntMap-merge based EventWriterT

### DIFF
--- a/bench/RunAll.hs
+++ b/bench/RunAll.hs
@@ -122,6 +122,7 @@ benchmarks = implGroup "spider" runSpiderHost cases
     merging n    = group ("merging "   <> show n) $ Focused.merging n
     dynamics n   = group ("dynamics "  <> show n) $ Focused.dynamics n
     shared w     = group ("sharedInvalidators " <> show w) $ Focused.sharedInvalidators w
+    eventWriter w = group ("eventWriter " <> show w) $ Focused.eventWriters w
     cases = concat
       [ sub 100 40
       , dynamics 100
@@ -136,6 +137,8 @@ benchmarks = implGroup "spider" runSpiderHost cases
       , shared 100
       , shared 300
       , shared 1000
+      , eventWriter 100
+      , eventWriter 1000
       ]
 
 pattern RunTestCaseFlag = "--run-test-case"

--- a/src/Reflex/EventWriter/Base.hs
+++ b/src/Reflex/EventWriter/Base.hs
@@ -34,7 +34,6 @@ import Reflex.TriggerEvent.Class
 import Control.Monad.Catch (MonadMask, MonadThrow, MonadCatch)
 import Control.Monad.Exception
 import Control.Monad.Fix
-import Control.Monad.Identity
 import Control.Monad.Morph
 import Control.Monad.Primitive
 import Control.Monad.Reader
@@ -42,10 +41,9 @@ import Control.Monad.Ref
 import Control.Monad.State.Strict
 import Data.Dependent.Map (DMap)
 import qualified Data.Dependent.Map as DMap
-import Data.Dependent.Sum (DSum (..))
 import Data.Functor.Compose
 import Data.Functor.Misc
-import Data.GADT.Compare (GCompare (..), GEq (..), GOrdering (..))
+import Data.GADT.Compare (GCompare)
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import Data.List.NonEmpty (NonEmpty (..))
@@ -54,50 +52,9 @@ import qualified Data.Map as Map
 import Data.Semigroup
 import Data.Some (Some)
 import Data.Tuple
-import Data.Type.Equality
-
-import Unsafe.Coerce
-
-{-# DEPRECATED TellId "Do not construct this directly; use tellId instead" #-}
-newtype TellId w x
-  = TellId Int -- ^ WARNING: Do not construct this directly; use 'tellId' instead
-  deriving (Show, Eq, Ord, Enum)
-
-tellId :: Int -> TellId w w
-tellId = TellId
-{-# INLINE tellId #-}
-
-tellIdRefl :: TellId w x -> w :~: x
-tellIdRefl _ = unsafeCoerce Refl
-
-withTellIdRefl :: TellId w x -> (w ~ x => r) -> r
-withTellIdRefl tid r = case tellIdRefl tid of
-  Refl -> r
-
-instance GEq (TellId w) where
-  a `geq` b =
-    withTellIdRefl a $
-    withTellIdRefl b $
-    if a == b
-    then Just Refl
-    else Nothing
-
-instance GCompare (TellId w) where
-  a `gcompare` b =
-    withTellIdRefl a $
-    withTellIdRefl b $
-    case a `compare` b of
-      LT -> GLT
-      EQ -> GEQ
-      GT -> GGT
-
-data EventWriterState t w = EventWriterState
-  { _eventWriterState_nextId :: {-# UNPACK #-} !Int -- Always negative (and decreasing over time)
-  , _eventWriterState_told :: ![DSum (TellId w) (Event t)] -- In increasing order
-  }
 
 -- | A basic implementation of 'EventWriter'.
-newtype EventWriterT t w m a = EventWriterT { unEventWriterT :: StateT (EventWriterState t w) m a }
+newtype EventWriterT t w m a = EventWriterT { unEventWriterT :: StateT [Event t w] m a }
   deriving
     ( Functor
     , Applicative
@@ -113,23 +70,27 @@ newtype EventWriterT t w m a = EventWriterT { unEventWriterT :: StateT (EventWri
     , MonadThrow
     )
 
+-- TODO: When 'Data.IntMap.fromDistinctDescList' becomes available
+-- (https://github.com/haskell/containers/pull/1194), key the reversed list with
+-- descending keys instead, so that 'combineResults' can use 'IntMap.elems'
+-- directly.
+
+-- TODO: If the 'Semigroup' were known to be commutative, the intermediate
+-- 'IntMap's could be avoided. (See
+-- https://github.com/reflex-frp/reflex/issues/538)
+
 -- | Run a 'EventWriterT' action.
 runEventWriterT :: forall t m w a. (Reflex t, Monad m, Semigroup w) => EventWriterT t w m a -> m (a, Event t w)
 runEventWriterT (EventWriterT a) = do
-  (result, requests) <- runStateT a $ EventWriterState (-1) []
-  let combineResults :: DMap (TellId w) Identity -> w
+  (result, told) <- runStateT a []
+  let combineResults :: IntMap w -> w
       combineResults = sconcat
-        . (\(h : t) -> h :| t) -- Unconditional; 'merge' guarantees that it will only fire with non-empty DMaps
-        . DMap.foldlWithKey (\vs tid (Identity v) -> withTellIdRefl tid $ v : vs) [] -- This is where we finally reverse the DMap to get things in the correct order
-  return (result, fmap combineResults $ merge $ DMap.fromDistinctAscList $ _eventWriterState_told requests) --TODO: We can probably make this fromDistinctAscList more efficient by knowing the length in advance, but this will require exposing internals of DMap; also converting it to use a strict list might help
+        . (\(h : t) -> h :| t) -- Unconditional; 'mergeInt' guarantees that it will only fire with non-empty IntMaps
+        . IntMap.foldl (flip (:)) [] -- Ascending key order is reverse tell order, so prepend while traversing to restore tell order
+  return (result, fmap combineResults $ mergeInt $ IntMap.fromDistinctAscList $ zip [0 ..] told)
 
 instance (Reflex t, Monad m, Semigroup w) => EventWriter t w (EventWriterT t w m) where
-  tellEvent w = EventWriterT $ modify $ \old ->
-    let myId = _eventWriterState_nextId old
-    in EventWriterState
-       { _eventWriterState_nextId = pred myId
-       , _eventWriterState_told = (tellId myId :=> w) : _eventWriterState_told old
-       }
+  tellEvent w = EventWriterT $ modify (w :)
 
 instance MonadSample t m => MonadSample t (EventWriterT t w m) where
   sample = lift . sample

--- a/test/Reflex/Bench/Focused.hs
+++ b/test/Reflex/Bench/Focused.hs
@@ -19,6 +19,7 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.Fix
 import Control.Monad.Identity
+import Control.Monad.Trans.Class (lift)
 import Data.Traversable (for, traverse)
 
 import qualified Data.Dependent.Map as DMap
@@ -294,6 +295,15 @@ merging n =
     counters :: TestPlan t m => m [Behavior t Int]
     counters = countMany =<< sparse
 
+
+eventWriters :: Word -> [(String, TestCase)]
+eventWriters n =
+  [ testE "firing"      $ fmapCheap sum <$> (tellMany =<< events 10)
+  , testE "subscribing" $ switches 10 (fmap (fmapCheap sum) . tellMany)
+  ]
+  where
+    tellMany :: (Reflex t, Monad m) => Event t Word -> m (Event t [Word])
+    tellMany e = fmap snd $ runEventWriterT $ forM_ [1 .. n] $ \i -> tellEvent $ fmapCheap ((: []) . (+ i)) e
 
 
 fans :: Word -> [(String, TestCase)]


### PR DESCRIPTION
Use IntMap over DMap-based merge in EventWriterT. RequesterT had already received similar treatment, but EventWriterT was never updated similarly.

Adds a simple benchmark:

```
Benchmark                             HEAD^1            HEAD               Ratio
--------------------------------------------------------------------------------
eventWriter 100/firing            1.7 ms ±5%    633.1 us ±5%  0.37x* [0.33-0.40]
eventWriter 100/subscribing       5.7 ms ±7%      3.6 ms ±4%  0.63x* [0.56-0.68]
eventWriter 1000/firing          23.4 ms ±3%      6.4 ms ±3%  0.28x* [0.26-0.29]
eventWriter 1000/subscribing     98.5 ms ±3%     58.8 ms ±3%  0.60x* [0.56-0.63]
```
