### PR TITLE
Extra tests

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -85,6 +85,8 @@ micros =
         fireEvents [key :=> Identity (42 :: Int)])
   , withSetupWHNF "hold" newEventWithTriggerRef $ \(ev, _) -> hold (42 :: Int) ev
   , withSetupWHNF "sample" (newEventWithTriggerRef >>= hold (42 :: Int) . fst) sample
+  , withSetupWHNF "headE" newEventWithTriggerRef $ \(ev, _) -> runHostFrame (headE ev)
+  , withSetupWHNF "subscribeHeadE" (newEventWithTriggerRef >>= runHostFrame . headE . fst) subscribeEvent
   ]
 
 setupMerge :: Int

--- a/bench/RunAll.hs
+++ b/bench/RunAll.hs
@@ -118,6 +118,7 @@ benchmarks = implGroup "spider" runSpiderHost cases
     implGroup name runHost = group name . fmap (second (benchFiring runHost))
     group name = fmap $ first ((name <> "/") <>)
     sub n frames = group ("subscribing " ++ show (n, frames)) $ Focused.subscribing n frames
+    headEs n frames = group ("headE " ++ show (n, frames)) $ Focused.headEs n frames
     firing n     = group ("firing "    <> show n) $ Focused.firing n
     merging n    = group ("merging "   <> show n) $ Focused.merging n
     dynamics n   = group ("dynamics "  <> show n) $ Focused.dynamics n
@@ -125,6 +126,7 @@ benchmarks = implGroup "spider" runSpiderHost cases
     eventWriter w = group ("eventWriter " <> show w) $ Focused.eventWriters w
     cases = concat
       [ sub 100 40
+      , headEs 100 40
       , dynamics 100
       , dynamics 1000
       , firing 1000

--- a/test/GC.hs
+++ b/test/GC.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE LambdaCase #-}
 module Main where
 
 import Control.Monad
@@ -23,6 +24,7 @@ import Data.Type.Equality ((:~:)(Refl))
 import Data.Functor.Misc
 import Data.Patch
 
+import qualified Reflex.Class as R
 import qualified Reflex.Host.Class as Host
 import qualified Reflex.Spider.Internal as S
 
@@ -35,6 +37,29 @@ main = do
   ref <- newIORef Nothing
   hostPerf ref
   readIORef ref >>= maybe exitFailure (putStrLn . ("Result " <>) . show)
+  headEAtMostOnce <- checkHeadEAtMostOnce
+  if headEAtMostOnce
+    then putStrLn "headE at-most-once holds under GC"
+    else do
+      putStrLn "headE fired for a subscriber that subscribed after its first occurrence"
+      exitFailure
+
+checkHeadEAtMostOnce :: IO Bool
+checkHeadEAtMostOnce = S.runSpiderHost $ do
+  (inputEvent, inputTriggerRef) <- Host.newEventWithTriggerRef
+  -- fmap goes through push/cacheEvent, whose subscribers live in a weak bag;
+  -- a plain root event may retain its subscribers strongly and mask the bug.
+  headOfInput <- Host.runHostFrame $ R.headE (fmap id (inputEvent :: R.Event S.Spider String))
+  liftIO performMajorGC
+  Just trigger <- liftIO $ readIORef inputTriggerRef
+  Host.fireEvents [trigger :=> Identity "first"]
+  liftIO performMajorGC
+  lateHandle <- Host.subscribeEvent headOfInput
+  lateOccurrence <- Host.fireEventsAndRead [trigger :=> Identity "second"] $
+    Host.readEvent lateHandle >>= \case
+      Nothing -> return Nothing
+      Just getValue -> Just <$> getValue
+  return $ lateOccurrence == Nothing
 
 hostPerf :: IORef (Maybe Int) -> IO ()
 hostPerf ref = S.runSpiderHost $ do

--- a/test/Reflex/Bench/Focused.hs
+++ b/test/Reflex/Bench/Focused.hs
@@ -170,9 +170,28 @@ switchPromptlyChain :: (Reflex t, MonadHold t m) => Word -> Event t Word -> m (E
 switchPromptlyChain = iterM $ \e ->
     switchPromptlyDyn <$> holdDyn e (e <$ e)
 
+-- Like switchPromptlyChain, but each level alternates between two distinct
+-- events instead of re-assigning the one it already holds: the two chains
+-- bracket implementations that reuse the current subscription when the
+-- switched-to event is unchanged (switchPromptlyChain rewards such reuse
+-- maximally; this chain never allows it).
+switchPromptlyChain2 :: (Reflex t, MonadHold t m, MonadFix m) => Word -> Event t Word -> m (Event t Word)
+switchPromptlyChain2 = iterM $ \e -> do
+    d <- foldDyn (const swap) (e, (+1) <$> e) e
+    return $ switchPromptlyDyn (fst <$> d)
+
 
 coinChain :: Reflex t => Word -> Event t Word -> Event t Word
 coinChain = iter $ \e -> coincidence (e <$ e)
+
+headEChain :: (Reflex t, MonadHold t m) => Word -> Event t Word -> m (Event t Word)
+headEChain = iterM headE
+
+headEFan :: (Reflex t, MonadHold t m) => Word -> Event t Word -> m (Event t Word)
+headEFan n e = mergeTree 8 <$> traverse headE (fmapFan n e)
+
+headEShared :: (Reflex t, MonadHold t m) => Word -> Event t Word -> m (Event t Word)
+headEShared n e = mergeTree 8 . fmapFan n <$> headE e
 
 fanMergeChain :: Reflex t => Word -> Word -> Event t Word -> Event t Word
 fanMergeChain width = iter $ fanMerge width
@@ -260,10 +279,24 @@ subscribing n frames =
   , testSub "fmapChain"           $ return . fmapChain n
   , testSub "switchChain"         $ switchChain n
   , testSub "switchPromptlyChain" $ switchPromptlyChain n
+  , testSub "switchPromptlyChain2" $ switchPromptlyChain2 n
   , testSub "switchFactors"       $ switchFactors n
   , testSub "coincidenceChain"    $ return . coinChain n
   ]
 
+  where
+    testSub :: (Eq a, Show a, NFData a) => String -> (forall t n. (Reflex t, MonadHold t n, MonadFix n) => Event t Word -> n (Event t a)) -> (String, TestCase)
+    testSub name test = testE name (switches frames test)
+
+-- Set of benchmarks to compare headE implementations. The networks are
+-- rebuilt (and their input fires, spending every headE) on each frame, so
+-- creation, frame-end init, subscription and spend/teardown are all measured.
+headEs :: Word -> Word -> [(String, TestCase)]
+headEs n frames =
+  [ testSub "headEChain"  $ headEChain n
+  , testSub "headEFan"    $ headEFan n
+  , testSub "headEShared" $ headEShared n
+  ]
   where
     testSub :: (Eq a, Show a, NFData a) => String -> (forall t n. (Reflex t, MonadHold t n, MonadFix n) => Event t Word -> n (Event t a)) -> (String, TestCase)
     testSub name test = testE name (switches frames test)
@@ -350,6 +383,7 @@ firing n =
   [ testE "fmapChain"           $ fmapChain n <$> e
   , testE "switchChain2"        $ switchChain2 n =<< e
   , testE "switchPromptlyChain" $ switchPromptlyChain n =<< e
+  , testE "switchPromptlyChain2" $ switchPromptlyChain2 n =<< e
   , testE "switchFactors"       $  switchFactors n =<< e
   , testE "coincidenceChain"    $ coinChain n <$> e
 

--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -121,6 +121,12 @@ testCases =
       b <- hold never (e <$ e)
       headE $ switch b
 
+  , testE' "headE-rec" [(1,"a")] $ do
+      e <- events1
+      rec !eHeadOfLater <- headE eLater
+          eLater <- headE e
+      return eHeadOfLater
+
   , testE' "switch-1" [(2,"b"),(5,"c"),(7,"d"),(8,"e")] $ do
       e <- events1
       b <- hold never (e <$ e)
@@ -366,8 +372,98 @@ testCases =
   , testE' "now-2" [(1,())] $ do
       e1 <- events1
       let e = pushAlways (\a -> if a == "a" then now else return never) e1
-      x <- accumDyn (<>) never e 
+      x <- accumDyn (<>) never e
       return . coincidence $ updated x
+
+  , testE' "dynamic-bind-lazy-function" [(3,"a")] $ do
+      e <- plan [(1, "a")]
+      eLater <- plan [(3, ())]
+      dReady <- holdDyn False (True <$ e)
+      dPayload <- holdDyn "payload" e
+      let dJoined = dReady >>= \ready ->
+            if ready then dPayload else error "dynamic-bind: function applied to unobserved value"
+      return $ tag (current dJoined) eLater
+
+  , testE' "dynamic-bind-forced-at-build" [(3,"a")] $ do
+      e <- plan [(1, "a")]
+      eLater <- plan [(3, ())]
+      dReady <- holdDyn False (True <$ e)
+      dPayload <- holdDyn "payload" e
+      let dJoined = dReady >>= \ready ->
+            if ready then dPayload else error "dynamic-bind: function applied to unobserved value"
+      dJoined `seq` return (tag (current dJoined) eLater)
+
+  -- An fmap'd Dynamic that is forced but never sampled or subscribed must not
+  -- sample the Dynamic it maps over.
+  , testB' "dynamic-fmap-dead" [(0,"ok"),(1,"ok"),(2,"x")] $ do
+      e <- plan [(1, "x")]
+      let divergingBehavior :: forall t. Reflex t => Event t () -> Behavior t String
+          divergingBehavior _timelinePin = fix $ \bLoop -> fmap ('!':) bLoop
+      let dDead = fmap (map toUpper) (unsafeDynamic (divergingBehavior (void e)) never)
+      dDead `seq` hold "ok" e
+
+  -- A joined Dynamic that is forced but never sampled or subscribed must not
+  -- sample its outer or inner Dynamics.
+  , testB' "dynamic-join-dead" [(0,"ok"),(1,"ok"),(2,"x")] $ do
+      e <- plan [(1, "x")]
+      -- A dynamic that refers to itself through 'join': a bottom placeholder
+      -- that must stay inert while unobserved. The event argument only pins the
+      -- timeline type.
+      let selfReferentialDynamic :: forall t. Reflex t => Event t () -> Dynamic t String
+          selfReferentialDynamic _timelinePin = fix $ \dLoop -> join (pure dLoop)
+      selfReferentialDynamic (void e) `seq` hold "ok" e
+
+  -- unsafeBuildDynamic's initial-value computation runs no earlier than the
+  -- first observation of the Dynamic.
+  , testE' "unsafeBuildDynamic-seed-timing" [(3,"b")] $ do
+      e <- plan [(1, "a"), (2, "b")]
+      eLater <- plan [(3, ())]
+      b <- hold "0" e
+      let d = unsafeBuildDynamic (sample b) never
+      d `seq` return (tag (current d) eLater)
+
+  -- buildDynamic's initial-value computation runs during the frame that
+  -- builds it.
+  , testE' "buildDynamic-seed-timing" [(3,"0")] $ do
+      e <- plan [(1, "a"), (2, "b")]
+      eLater <- plan [(3, ())]
+      b <- hold "0" e
+      d <- buildDynamic (sample b) never
+      return (tag (current d) eLater)
+
+  -- buildDynamic inside a recursive knot, whose initial-value computation
+  -- scrutinizes a value sampled from a Dynamic bound later in the same knot.
+  , testB' "buildDynamic-rec-scrutinize" [(0,5),(1,5)] $ do
+      rec dScrutinized <- buildDynamic
+            (do seed <- sample (current dLater)
+                if seed > (0 :: Int) then return seed else return 0)
+            never
+          dLater <- holdDyn 5 never
+      return (current dScrutinized)
+
+  -- The lazy-hold knot with an fmap between the hold and the switch.
+  , testE' "lazy-hold-fmap" [(1,()),(2,())] $ do
+      let lazyHoldFmap :: forall t m. (Reflex t, MonadHold t m, MonadFix m) => m (Event t ())
+          lazyHoldFmap = do
+            rec !b <- hold never e
+                let e = never <$ switch (fmap id b)
+            return $ void e
+      e0 <- plan [(1, ()), (2, ())]
+      tickle <- lazyHoldFmap
+      return $ leftmost [tickle, e0]
+
+  , testE' "switch-fmap-behavior" [(1,"hia"),(2,"lob"),(3,"hic"),(4,"lod")] $ do
+      e1 <- plan [(1, "a"), (2, "b"), (3, "c"), (4, "d")]
+      rec bFlag <- hold True (not <$> tag bFlag e1)
+      let bE = (\f -> if f then ("hi" ++) <$> e1 else ("lo" ++) <$> e1) <$> bFlag
+      return (switch bE)
+
+  , testE' "coincidence-pull-switch-height" [(1,()),(2,()),(3,()),(4,())] $ do
+      tick <- plan [(1, ()), (2, ()), (3, ()), (4, ())]
+      rec bFlag <- hold False (not <$> tag bFlag tick)
+      let hi = leftmost [tick, tick]
+          bE = (\f -> if f then hi else tick) <$> bFlag
+      return $ leftmost [void (coincidence (switch bE <$ hi)), tick]
   ] where
 
     events1, events2, events3 ::  TestPlan t m => m (Event t String)


### PR DESCRIPTION
Some tests I've collected while messing with Reflex' implementation.

The tests capture the current laziness behavior of Dynamics, and a test for the incorrect headE implementation currently in tree but unused.