### PR TITLE
Remove MonadHold/MonadSample instances of SpiderHost

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -55,7 +55,9 @@ micros =
   , bench "newEventWithTriggerRef" $ whnfIO . void $ runSpiderHost newEventWithTriggerRef
   , withSetupWHNF "subscribeEvent" newEventWithTriggerRef $ subscribeEvent . fst
   , withSetupWHNF "subscribeSwitch"
-    (join $ hold <$> fmap fst newEventWithTriggerRef <*> fmap fst newEventWithTriggerRef)
+    (do iv <- fst <$> newEventWithTriggerRef
+        ev <- fst <$> newEventWithTriggerRef
+        runHostFrame (hold iv ev))
     (subscribeEvent . switch)
   , withSetupWHNF "subscribeMerge(1)" (setupMerge 1) $ \(ev,_) -> subscribeEvent ev
   , withSetupWHNF "subscribeMerge(100)" (setupMerge 100) (subscribeEvent . fst)
@@ -83,8 +85,8 @@ micros =
     (\(_, t:_) -> do
         key <- fromJust <$> liftIO (readIORef t)
         fireEvents [key :=> Identity (42 :: Int)])
-  , withSetupWHNF "hold" newEventWithTriggerRef $ \(ev, _) -> hold (42 :: Int) ev
-  , withSetupWHNF "sample" (newEventWithTriggerRef >>= hold (42 :: Int) . fst) sample
+  , withSetupWHNF "hold" newEventWithTriggerRef $ \(ev, _) -> runHostFrame (hold (42 :: Int) ev)
+  , withSetupWHNF "sample" (newEventWithTriggerRef >>= runHostFrame . hold (42 :: Int) . fst) (runHostFrame . sample)
   , withSetupWHNF "headE" newEventWithTriggerRef $ \(ev, _) -> runHostFrame (headE ev)
   , withSetupWHNF "subscribeHeadE" (newEventWithTriggerRef >>= runHostFrame . headE . fst) subscribeEvent
   ]

--- a/bench/RunAll.hs
+++ b/bench/RunAll.hs
@@ -84,7 +84,7 @@ instance NFData (Firing t) where
   rnf !_ = ()
 
 -- Measure the running time
-benchFiring :: forall t m. (MonadReflexHost' t m, MonadSample t m) => (forall a. m a -> IO a) -> TestCase -> Int -> IO ()
+benchFiring :: forall t m. (MonadReflexHost' t m) => (forall a. m a -> IO a) -> TestCase -> Int -> IO ()
 benchFiring runHost tc n = runHost $ do
   let runIterations :: m a -> m ()
       runIterations test = replicateM_ (10*n) $ do
@@ -114,7 +114,7 @@ waitForFinalizers = do
 benchmarks :: [(String, Int -> IO ())]
 benchmarks = implGroup "spider" runSpiderHost cases
   where
-    implGroup :: (MonadReflexHost' t m, MonadSample t m) => String -> (forall a. m a -> IO a) -> [(String, TestCase)] -> [(String, Int -> IO ())]
+    implGroup :: (MonadReflexHost' t m) => String -> (forall a. m a -> IO a) -> [(String, TestCase)] -> [(String, Int -> IO ())]
     implGroup name runHost = group name . fmap (second (benchFiring runHost))
     group name = fmap $ first ((name <> "/") <>)
     sub n frames = group ("subscribing " ++ show (n, frames)) $ Focused.subscribing n frames

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -157,7 +157,7 @@ instance ReflexHost t => MonadSample t (PerformEventT t m) where
   {-# INLINABLE sample #-}
   sample = PerformEventT . lift . sample
 
-instance (ReflexHost t, MonadHold t m) => MonadHold t (PerformEventT t m) where
+instance ReflexHost t => MonadHold t (PerformEventT t m) where
   {-# INLINABLE hold #-}
   hold v0 v' = PerformEventT $ lift $ hold v0 v'
   {-# INLINABLE holdDyn #-}

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2637,21 +2637,6 @@ holdIncrementalSpiderEventM v0 e = fmap (SpiderIncremental . dynamicHold) $ Refl
 buildDynamicSpiderEventM :: HasSpiderTimeline x => SpiderPushM x a -> Reflex.Class.Event (SpiderTimeline x) a -> EventM x (Reflex.Class.Dynamic (SpiderTimeline x) a)
 buildDynamicSpiderEventM getV0 e = fmap (SpiderDynamic . dynamicDynIdentity) $ Reflex.Spider.Internal.buildDynamic (coerce getV0) $ coerce $ unSpiderEvent e
 
-instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (SpiderHost x) where
-  {-# INLINABLE hold #-}
-  hold v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.hold v0 e
-  {-# INLINABLE holdDyn #-}
-  holdDyn v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdDyn v0 e
-  {-# INLINABLE holdIncremental #-}
-  holdIncremental v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdIncremental v0 e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = runFrame . runSpiderHostFrame $ Reflex.Class.buildDynamic getV0 e
-  {-# INLINABLE headE #-}
-  headE e = runFrame . runSpiderHostFrame $ Reflex.Class.headE e
-  {-# INLINABLE now #-}
-  now = runFrame . runSpiderHostFrame $ Reflex.Class.now
-
-
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHostFrame x) where
   sample = SpiderHostFrame . readBehaviorUntracked . unSpiderBehavior --TODO: This can cause problems with laziness, so we should get rid of it if we can
 
@@ -2669,10 +2654,6 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
 --  headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderHostFrame Reflex.Class.now
-
-instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHost x) where
-  {-# INLINABLE sample #-}
-  sample = runFrame . readBehaviorUntracked . unSpiderBehavior
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (Reflex.Spider.Internal.ReadPhase x) where
   {-# INLINABLE sample #-}

--- a/test/Reflex/Test/CrossImpl.hs
+++ b/test/Reflex/Test/CrossImpl.hs
@@ -77,18 +77,20 @@ instance (MapMSignals a a' t t', MapMSignals b b' t t') => MapMSignals (a, b) (a
 testTimeline
   :: (forall m t. TestCaseConstraint t m => (Behavior t a, Event t b) -> m (Behavior t c, Event t d))
   -> (Map Int a, Map Int b)
-  -> (forall m t. (MonadReflexHost t m, MonadIO m, MonadRef m, Ref m ~ Ref IO, MonadSample t m) => m (Map Int c, Map Int d))
+  -> (forall m t. (MonadReflexHost t m, MonadIO m, MonadRef m, Ref m ~ Ref IO) => m (Map Int c, Map Int d))
 testTimeline builder (bMap, eMap) = do
   (re, reTrigger) <- newEventWithTriggerRef
   (rb, rbTrigger) <- newEventWithTriggerRef
-  b <- runHostFrame $ hold (error "testTimeline: No value for input behavior yet") rb
-  (b', e') <- runHostFrame $ builder (b, re)
+  (b, b', e') <- runHostFrame $ do
+    b <- hold (error "testTimeline: No value for input behavior yet") rb
+    (b', e') <- builder (b, re)
+    pure (b, b', e')
   e'Handle <- subscribeEvent e' --TODO: This should be unnecessary
   let times = relevantTestingTimes (bMap, eMap)
   liftIO performGC
   outputs <- forM times $ \t -> do
     forM_ (Map.lookup t bMap) $ \val -> mapM_ (\ rbt -> fireEvents [rbt :=> Identity val]) =<< readRef rbTrigger
-    bOutput <- sample b'
+    bOutput <- runHostFrame $ sample b'
     eOutput <- fmap join $ forM (Map.lookup t eMap) $ \val -> do
       mret <- readRef reTrigger
       let firing = case mret of

--- a/test/Test/Run.hs
+++ b/test/Test/Run.hs
@@ -29,11 +29,12 @@ runApp :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
 runApp app b0 input = runSpiderHost $ do
   (appInHoldE, pulseHoldTriggerRef) <- newEventWithTriggerRef
   (appInE, pulseEventTriggerRef) <- newEventWithTriggerRef
-  appInB <- hold b0 appInHoldE
-  (out, FireCommand fire) <- hostPerformEventT $ app $ AppIn
-    { _appIn_event = appInE
-    , _appIn_behavior = appInB
-    }
+  (out, FireCommand fire) <- hostPerformEventT $ do
+    appInB <- hold b0 appInHoldE
+    app $ AppIn
+      { _appIn_event = appInE
+      , _appIn_behavior = appInB
+      }
   hnd <- subscribeEvent (_appOut_event out)
   mpulseB <- readRef pulseHoldTriggerRef
   mpulseE <- readRef pulseEventTriggerRef

--- a/test/rootCleanup.hs
+++ b/test/rootCleanup.hs
@@ -14,7 +14,7 @@ main = do
       e <- newEventWithTrigger $ \_ -> do
         modifyIORef' numSubscriptions succ
         return $ modifyIORef' numSubscriptions pred
-      _ <- hold () e
+      _ <- runHostFrame $ hold () e
       return ()
     replicateM_ 100 $ do
       performMajorGC


### PR DESCRIPTION
These instances allowed Reflex hosts to muddle their setup-timing. With this change we make it harder to make "logical time" mistakes when writing Reflex hosts. If we want to make the `now` primitive useful, we need to stop firing arbitrary frames. This is a first step in increasing that discipline, by way of making `runFrame` explicit in the code.