### PR TITLE
Improve Spider's time discipline, deprecate PostBuild

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -53,13 +53,15 @@ micros =
   , bench "newEventWithTrigger" $ whnfIO . void $ runSpiderHost $ newEventWithTrigger $
       \trigger -> return () <$ evaluate trigger
   , bench "newEventWithTriggerRef" $ whnfIO . void $ runSpiderHost newEventWithTriggerRef
-  , withSetupWHNF "subscribeEvent" newEventWithTriggerRef $ subscribeEvent . fst
+  , withSetupWHNF "subscribeEvent" newEventWithTriggerRef $ runHostFrame . subscribeEvent . fst
   , withSetupWHNF "subscribeSwitch"
-    (join $ hold <$> fmap fst newEventWithTriggerRef <*> fmap fst newEventWithTriggerRef)
-    (subscribeEvent . switch)
-  , withSetupWHNF "subscribeMerge(1)" (setupMerge 1) $ \(ev,_) -> subscribeEvent ev
-  , withSetupWHNF "subscribeMerge(100)" (setupMerge 100) (subscribeEvent . fst)
-  , withSetupWHNF "subscribeMerge(10000)" (setupMerge 10000) (subscribeEvent . fst)
+    (do iv <- fst <$> newEventWithTriggerRef
+        ev <- fst <$> newEventWithTriggerRef
+        runHostFrame (hold iv ev))
+    (runHostFrame . subscribeEvent . switch)
+  , withSetupWHNF "subscribeMerge(1)" (setupMerge 1) $ \(ev,_) -> runHostFrame $ subscribeEvent ev
+  , withSetupWHNF "subscribeMerge(100)" (setupMerge 100) (runHostFrame . subscribeEvent . fst)
+  , withSetupWHNF "subscribeMerge(10000)" (setupMerge 10000) (runHostFrame . subscribeEvent . fst)
   , bench "runHostFrame" $ whnfIO $ runSpiderHost $ runHostFrame $ return ()
   , withSetupWHNF "fireEventsAndRead(single/single)"
     (newEventWithTriggerRef >>= subscribePair)
@@ -83,10 +85,10 @@ micros =
     (\(_, t:_) -> do
         key <- fromJust <$> liftIO (readIORef t)
         fireEvents [key :=> Identity (42 :: Int)])
-  , withSetupWHNF "hold" newEventWithTriggerRef $ \(ev, _) -> hold (42 :: Int) ev
-  , withSetupWHNF "sample" (newEventWithTriggerRef >>= hold (42 :: Int) . fst) sample
+  , withSetupWHNF "hold" newEventWithTriggerRef $ \(ev, _) -> runHostFrame (hold (42 :: Int) ev)
+  , withSetupWHNF "sample" (newEventWithTriggerRef >>= runHostFrame . hold (42 :: Int) . fst) (runHostFrame . sample)
   , withSetupWHNF "headE" newEventWithTriggerRef $ \(ev, _) -> runHostFrame (headE ev)
-  , withSetupWHNF "subscribeHeadE" (newEventWithTriggerRef >>= runHostFrame . headE . fst) subscribeEvent
+  , withSetupWHNF "subscribeHeadE" (newEventWithTriggerRef >>= runHostFrame . headE . fst) (runHostFrame . subscribeEvent)
   ]
 
 setupMerge :: Int
@@ -99,7 +101,7 @@ setupMerge num = do
   pure (merge m, triggers)
 
 subscribePair :: (Event (SpiderTimeline Global) a, b) -> SpiderHost Global (EventHandle (SpiderTimeline Global) a, b)
-subscribePair (ev, b) = (,b) <$> subscribeEvent ev
+subscribePair (ev, b) = (,b) <$> runHostFrame (subscribeEvent ev)
 
 fireAndRead :: IORef (Maybe (EventTrigger (SpiderTimeline Global) a)) -> a -> EventHandle (SpiderTimeline Global) b
             -> SpiderHost Global (Maybe b)

--- a/bench/RunAll.hs
+++ b/bench/RunAll.hs
@@ -63,12 +63,6 @@ import qualified Data.Map as Map
 type MonadReflexHost' t m = (MonadReflexHost t m, MonadIORef m, MonadIORef (HostFrame t))
 
 
-setupFiring ::   (MonadReflexHost t m, MonadIORef m) => Plan t (Event t a) -> m (EventHandle t a, Schedule t)
-setupFiring p = do
-  (e, s) <- runPlan p
-  h <- subscribeEvent e
-  return (h, s)
-
 -- Hack to avoid the NFData constraint for EventHandle which is a synonym
 newtype Ignore a = Ignore a
 instance NFData (Ignore a) where
@@ -84,7 +78,7 @@ instance NFData (Firing t) where
   rnf !_ = ()
 
 -- Measure the running time
-benchFiring :: forall t m. (MonadReflexHost' t m, MonadSample t m) => (forall a. m a -> IO a) -> TestCase -> Int -> IO ()
+benchFiring :: forall t m. (MonadReflexHost' t m) => (forall a. m a -> IO a) -> TestCase -> Int -> IO ()
 benchFiring runHost tc n = runHost $ do
   let runIterations :: m a -> m ()
       runIterations test = replicateM_ (10*n) $ do
@@ -114,7 +108,7 @@ waitForFinalizers = do
 benchmarks :: [(String, Int -> IO ())]
 benchmarks = implGroup "spider" runSpiderHost cases
   where
-    implGroup :: (MonadReflexHost' t m, MonadSample t m) => String -> (forall a. m a -> IO a) -> [(String, TestCase)] -> [(String, Int -> IO ())]
+    implGroup :: (MonadReflexHost' t m) => String -> (forall a. m a -> IO a) -> [(String, TestCase)] -> [(String, Int -> IO ())]
     implGroup name runHost = group name . fmap (second (benchFiring runHost))
     group name = fmap $ first ((name <> "/") <>)
     sub n frames = group ("subscribing " ++ show (n, frames)) $ Focused.subscribing n frames

--- a/src/Reflex/Class.hs
+++ b/src/Reflex/Class.hs
@@ -187,6 +187,7 @@ import Control.Monad.Fix
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State.Strict
+import qualified Control.Monad.State.Lazy as Lazy
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.RWS (RWST)
@@ -622,6 +623,17 @@ instance MonadSample t m => MonadSample t (ContT r m) where
   sample = lift . sample
 
 instance MonadHold t m => MonadHold t (ContT r m) where
+  hold a0 = lift . hold a0
+  holdDyn a0 = lift . holdDyn a0
+  holdIncremental a0 = lift . holdIncremental a0
+  buildDynamic a0 = lift . buildDynamic a0
+  headE = lift . headE
+  now = lift now
+
+instance MonadSample t m => MonadSample t (Lazy.StateT s m) where
+  sample = lift . sample
+
+instance MonadHold t m => MonadHold t (Lazy.StateT r m) where
   hold a0 = lift . hold a0
   holdDyn a0 = lift . holdDyn a0
   holdIncremental a0 = lift . holdIncremental a0

--- a/src/Reflex/Collection.hs
+++ b/src/Reflex/Collection.hs
@@ -48,7 +48,6 @@ import Control.Monad.Identity
 import Reflex.Class
 import Reflex.Adjustable.Class
 import Reflex.Dynamic
-import Reflex.PostBuild.Class
 
 -- | Create a set of widgets based on the provided 'Map'. When the
 -- input 'Event' fires, remove widgets for keys with the value 'Nothing'
@@ -77,12 +76,12 @@ listHoldWithKey m0 m' f = do
 --where the Events carry diffs, not the whole value
 listWithKey
   :: forall t k v m a
-   . (Ord k, Adjustable t m, PostBuild t m, MonadFix m, MonadHold t m, Eq v)
+   . (Ord k, Adjustable t m, MonadFix m, MonadHold t m, Eq v)
   => Dynamic t (Map k v)
   -> (k -> Dynamic t v -> m a)
   -> m (Dynamic t (Map k a))
 listWithKey vals mkChild = do
-  postBuild <- getPostBuild
+  postBuild <- now
   let childValChangedSelector = fanMap $ updated vals
 
       -- We keep track of changes to children values in the mkChild
@@ -150,7 +149,7 @@ listWithKeyShallowDiff initialVals valsChanged mkChild = do
 --   this scenario, but 'listViewWithKey' flattens this to
 --   @/Event t (Map k a)/@ via 'switch'.
 listViewWithKey
-  :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m, Eq v)
+  :: (Ord k, Adjustable t m, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t (Map k v)
   -> (k -> Dynamic t v -> m (Event t a))
   -> m (Event t (Map k a))
@@ -158,7 +157,7 @@ listViewWithKey vals mkChild =
   switch . fmap mergeMap <$> listViewWithKey' vals mkChild
 
 listViewWithKey'
-  :: (Ord k, Adjustable t m, PostBuild t m, MonadHold t m, MonadFix m, Eq v)
+  :: (Ord k, Adjustable t m, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t (Map k v)
   -> (k -> Dynamic t v -> m a)
   -> m (Behavior t (Map k a))
@@ -168,7 +167,7 @@ listViewWithKey' vals mkChild = current <$> listWithKey vals mkChild
 -- selected at any time.
 selectViewListWithKey
   :: forall t m k v a
-   . (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m, Eq v)
+   . (Adjustable t m, Ord k, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t k
   -- ^ Current selection key
   -> Dynamic t (Map k v)
@@ -192,7 +191,7 @@ selectViewListWithKey selection vals mkChild = do
 -- item widget's output 'Event'.
 selectViewListWithKey_
   :: forall t m k v a
-   . (Adjustable t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m, Eq v)
+   . (Adjustable t m, Ord k, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t k
   -- ^ Current selection key
   -> Dynamic t (Map k v)
@@ -210,7 +209,7 @@ selectViewListWithKey_ selection vals mkChild =
 --   key/value map.  Unlike the 'withKey' variants, the child widgets
 --   are insensitive to which key they're associated with.
 list
-  :: (Ord k, Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m, Eq v)
+  :: (Ord k, Adjustable t m, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t (Map k v)
   -> (Dynamic t v -> m a)
   -> m (Dynamic t (Map k a))
@@ -218,7 +217,7 @@ list dm mkChild = listWithKey dm (\_ dv -> mkChild dv)
 
 -- | Create a dynamically-changing set of widgets from a Dynamic list.
 simpleList
-  :: (Adjustable t m, MonadHold t m, PostBuild t m, MonadFix m, Eq v)
+  :: (Adjustable t m, MonadHold t m, MonadFix m, Eq v)
   => Dynamic t [v]
   -> (Dynamic t v -> m a)
   -> m (Dynamic t [a])

--- a/src/Reflex/Host/Class.hs
+++ b/src/Reflex/Host/Class.hs
@@ -20,6 +20,8 @@ module Reflex.Host.Class
   , MonadReadEvent (..)
   , MonadReflexCreateTrigger (..)
   , MonadReflexHost (..)
+  , fireEventsAndRead
+  , runHostFrame
   , fireEvents
   , newEventWithTriggerRef
   , fireEventRef
@@ -30,6 +32,7 @@ import Reflex.Class
 
 import Control.Monad.Fix
 import Control.Monad.Identity
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Ref
 import Control.Monad.Trans
 import Control.Monad.Trans.Cont (ContT)
@@ -50,6 +53,7 @@ class ( Reflex t
       , MonadSample t (HostFrame t)
       , MonadHold t (HostFrame t)
       , MonadFix (HostFrame t)
+      , MonadIO (HostFrame t)
       , MonadSubscribeEvent t (HostFrame t)
       ) => ReflexHost t where
   type EventTrigger t :: Type -> Type
@@ -114,32 +118,54 @@ class ( ReflexHost t
       , MonadHold t (ReadPhase m)
       ) => MonadReflexHost t m | m -> t where
   type ReadPhase m :: Type -> Type
-  -- | Propagate some events firings and read the values of events afterwards.
+  -- | Run a 'HostFrame' action and, in the same instant, fire the triggers
+  -- it produces and observe the results.
   --
-  -- This function will create a new frame to fire the given events. It will
-  -- then update all dependent events and behaviors. After that is done, the
-  -- given callback is executed which allows to read the final values of events
-  -- and check whether they have fired in this frame or not.
+  -- The build action runs first and returns its result. After hold
+  -- initializations are processed (which subscribes holds to their events,
+  -- populating event trigger refs), the trigger extraction action runs and
+  -- returns the triggers to fire in this frame. The triggers are then
+  -- propagated, the read phase observes the settled frame, and only then
+  -- does finalization advance time. This matches the pure reference
+  -- semantics where build and frame 0 are the same instant, so a build-time
+  -- 'now' is observable.
   --
-  -- All events that are given are fired at the same time.
-  --
-  -- This function is typically used in the main loop of a reflex framework
-  -- implementation.  The main loop waits for external events to happen (such as
-  -- keyboard input or a mouse click) and then fires the corresponding events
-  -- using this function. The read callback can be used to read output events
-  -- and perform a corresponding response action to the external event.
-  fireEventsAndRead :: [DSum (EventTrigger t) Identity] -> ReadPhase m a -> m a
+  -- This is the sole primitive of the class: every frame an instance can run
+  -- goes through it, so building, firing, and reading cannot disagree about
+  -- what an instant is. 'fireEventsAndRead' (a frame with no build) and
+  -- 'runHostFrame' (a frame with no external triggers and no observation)
+  -- are derived from it.
+  hostFrameAndRead :: HostFrame t a -> (a -> HostFrame t [DSum (EventTrigger t) Identity]) -> (a -> ReadPhase m b) -> m b
 
-  -- | Run a frame without any events firing.
-  --
-  -- This function should be used when you want to use 'sample' and 'hold' when
-  -- no events are currently firing.  Using this function in that case can
-  -- improve performance, since the implementation can assume that no events are
-  -- firing when 'sample' or 'hold' are called.
-  --
-  -- This function is commonly used to set up the basic event network when the
-  -- application starts up.
-  runHostFrame :: HostFrame t a -> m a
+-- | Propagate some events firings and read the values of events afterwards.
+--
+-- This function will create a new frame to fire the given events. It will
+-- then update all dependent events and behaviors. After that is done, the
+-- given callback is executed which allows to read the final values of events
+-- and check whether they have fired in this frame or not.
+--
+-- All events that are given are fired at the same time.
+--
+-- This function is typically used in the main loop of a reflex framework
+-- implementation.  The main loop waits for external events to happen (such as
+-- keyboard input or a mouse click) and then fires the corresponding events
+-- using this function. The read callback can be used to read output events
+-- and perform a corresponding response action to the external event.
+fireEventsAndRead :: MonadReflexHost t m => [DSum (EventTrigger t) Identity] -> ReadPhase m a -> m a
+fireEventsAndRead inputs readPhase =
+  hostFrameAndRead (pure ()) (const (pure inputs)) (const readPhase)
+{-# INLINE fireEventsAndRead #-}
+
+-- | Run a frame without any events firing and without observing the frame.
+--
+-- This function should be used when you want to use 'sample' and 'hold' when
+-- no events are currently firing.
+--
+-- This function is commonly used to set up the basic event network when the
+-- application starts up.
+runHostFrame :: MonadReflexHost t m => HostFrame t a -> m a
+runHostFrame hostFrame = hostFrameAndRead hostFrame (const (pure [])) pure
+{-# INLINE runHostFrame #-}
 
 -- | Like 'fireEventsAndRead', but without reading any events.
 fireEvents :: MonadReflexHost t m => [DSum (EventTrigger t) Identity] -> m ()
@@ -199,8 +225,7 @@ instance MonadSubscribeEvent t m => MonadSubscribeEvent t (ReaderT r m) where
 
 instance MonadReflexHost t m => MonadReflexHost t (ReaderT r m) where
   type ReadPhase (ReaderT r m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 instance (MonadReflexCreateTrigger t m, Monoid w) => MonadReflexCreateTrigger t (WriterT w m) where
   newEventWithTrigger = lift . newEventWithTrigger
@@ -211,8 +236,7 @@ instance (MonadSubscribeEvent t m, Monoid w) => MonadSubscribeEvent t (WriterT w
 
 instance (MonadReflexHost t m, Monoid w) => MonadReflexHost t (WriterT w m) where
   type ReadPhase (WriterT w m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (StateT s m) where
   newEventWithTrigger = lift . newEventWithTrigger
@@ -223,8 +247,7 @@ instance MonadSubscribeEvent t m => MonadSubscribeEvent t (StateT r m) where
 
 instance MonadReflexHost t m => MonadReflexHost t (StateT s m) where
   type ReadPhase (StateT s m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 
 instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (Strict.StateT s m) where
@@ -236,8 +259,7 @@ instance MonadSubscribeEvent t m => MonadSubscribeEvent t (Strict.StateT r m) wh
 
 instance MonadReflexHost t m => MonadReflexHost t (Strict.StateT s m) where
   type ReadPhase (Strict.StateT s m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 
 
@@ -250,8 +272,7 @@ instance MonadSubscribeEvent t m => MonadSubscribeEvent t (ContT r m) where
 
 instance MonadReflexHost t m => MonadReflexHost t (ContT r m) where
   type ReadPhase (ContT r m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (ExceptT e m) where
   newEventWithTrigger = lift . newEventWithTrigger
@@ -262,8 +283,7 @@ instance MonadSubscribeEvent t m => MonadSubscribeEvent t (ExceptT r m) where
 
 instance MonadReflexHost t m => MonadReflexHost t (ExceptT e m) where
   type ReadPhase (ExceptT e m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase
 
 instance (MonadReflexCreateTrigger t m, Monoid w) => MonadReflexCreateTrigger t (RWST r w s m) where
   newEventWithTrigger = lift . newEventWithTrigger
@@ -274,5 +294,4 @@ instance (MonadSubscribeEvent t m, Monoid w) => MonadSubscribeEvent t (RWST r w 
 
 instance (MonadReflexHost t m, Monoid w) => MonadReflexHost t (RWST r w s m) where
   type ReadPhase (RWST r w s m) = ReadPhase m
-  fireEventsAndRead dm a = lift $ fireEventsAndRead dm a
-  runHostFrame = lift . runHostFrame
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead build getTriggers readPhase

--- a/src/Reflex/Host/Class.hs
+++ b/src/Reflex/Host/Class.hs
@@ -109,7 +109,6 @@ class (Applicative m, Monad m) => MonadReflexCreateTrigger t m | m -> t where
 -- | 'MonadReflexHost' designates monads that can run reflex frames.
 class ( ReflexHost t
       , MonadReflexCreateTrigger t m
-      , MonadSubscribeEvent t m
       , MonadReadEvent t (ReadPhase m)
       , MonadSample t (ReadPhase m)
       , MonadHold t (ReadPhase m)

--- a/src/Reflex/Host/Headless.hs
+++ b/src/Reflex/Host/Headless.hs
@@ -12,10 +12,9 @@ import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Fix (MonadFix, fix)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Primitive (PrimMonad)
-import Control.Monad.Ref (MonadRef, Ref, readRef)
+import Control.Monad.Ref (MonadRef, Ref)
 import Data.Dependent.Sum (DSum (..), (==>))
 import Data.Foldable (for_)
-import Data.Functor.Identity (Identity(..))
 import Data.IORef (IORef, readIORef)
 import Data.Maybe (catMaybes)
 import Data.Traversable (for)
@@ -61,40 +60,25 @@ runHeadlessApp
   -- closed at the first occurrence of the resulting 'Event'.
   -> IO a
 runHeadlessApp guest =
-  -- We are using the 'Spider' implementation of reflex. Running the host
-  -- allows us to take actions on the FRP timeline.
   withSpiderTimeline $ runSpiderHostForTimeline $ do
-    -- Create the "post-build" event and associated trigger. This event fires
-    -- once, when the application starts.
-    (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
     -- Queue of externally-triggered events awaiting processing.
     events <- liftIO newChan
-    -- Fold used for the post-build frame and for every event frame: stop as
-    -- soon as the guest's shutdown 'Event' fires, otherwise keep draining.
+    -- Fold used both for the initial settle and for every event frame: stop as
+    -- soon as the guest's shutdown 'Event' occurs, otherwise keep draining.
     let untilShutdown handle () = do
           mExit <- sequence =<< readEvent handle
           pure $ maybe (Right ()) Left mExit
-    -- Build the guest network. 'subscribeEvent' yields the shutdown handle; the
-    -- build settle observes nothing, since the post-build event has not fired.
-    (_, shutdownEventHandle, _, fc) <- hostPerformEventTAndRead
-          ( flip runPostBuildT postBuild   -- guest can access the post-build 'Event'
+    (_, shutdownEventHandle, shutdownImmediately, fc) <- hostPerformEventTAndRead
+          ( runPostBuildT   -- guest can access the post-build 'Event'
           . flip runTriggerEventT events   -- guest can create triggers, queued to 'events'
           $ guest )
           subscribeEvent
           ()
           untilShutdown
-    -- Read the post-build trigger. 'Nothing' if the guest never subscribed.
-    mPostBuildTrigger <- readRef postBuildTriggerRef
-    -- Fire the post-build event as the first frame (when subscribed), draining
-    -- its performEvent cascade and aborting the moment the shutdown 'Event' fires.
-    shutdownImmediately <- case mPostBuildTrigger of
-      Nothing -> pure (Right ())
-      Just postBuildTrigger ->
-        runFireCommandAndRead fc [postBuildTrigger :=> Identity ()] () (untilShutdown shutdownEventHandle)
     case shutdownImmediately of
       Left exitResult -> pure exitResult
-      -- Main loop: block for the next external event, fire it, and drain --
-      -- aborting the moment the shutdown 'Event' fires.
+      -- Main loop: block for the next external event, fire it, perform the effects
+      -- aborting the moment the shutdown 'Event' occurs.
       Right () -> fix $ \loop -> do
         ers <- liftIO $ readChan events
         mes <- liftIO $

--- a/src/Reflex/Host/Headless.hs
+++ b/src/Reflex/Host/Headless.hs
@@ -95,8 +95,9 @@ runHeadlessApp guest =
 
     -- Subscribe to an 'Event' of that the guest application can use to
     -- request application shutdown. We'll check whether this 'Event' is firing
-    -- to determine whether to terminate.
-    shutdown <- subscribeEvent result
+    -- to determine whether to terminate. Subscribing requires a frame of its
+    -- own here; it precedes the post-build frame below either way.
+    shutdown <- runHostFrame $ subscribeEvent result
 
     -- When there is a subscriber to the post-build event, fire the event.
     initialShutdownEventFirings :: Maybe [Maybe a] <- for mPostBuildTrigger $ \postBuildTrigger ->

--- a/src/Reflex/Host/Headless.hs
+++ b/src/Reflex/Host/Headless.hs
@@ -14,7 +14,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Primitive (PrimMonad)
 import Control.Monad.Ref (MonadRef, Ref, readRef)
 import Data.Dependent.Sum (DSum (..), (==>))
-import Data.Foldable (for_, asum)
+import Data.Foldable (for_)
 import Data.Functor.Identity (Identity(..))
 import Data.IORef (IORef, readIORef)
 import Data.Maybe (catMaybes)
@@ -67,84 +67,40 @@ runHeadlessApp guest =
     -- Create the "post-build" event and associated trigger. This event fires
     -- once, when the application starts.
     (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
-    -- Create a queue to which we will write 'Event's that need to be
-    -- processed.
+    -- Queue of externally-triggered events awaiting processing.
     events <- liftIO newChan
-    -- Run the "guest" application, providing the appropriate context. We'll
-    -- pure the result of the action, and a 'FireCommand' that will be used to
-    -- trigger events.
-    (result, fc@(FireCommand fire)) <- do
-      hostPerformEventT $                 -- Allows the guest app to run
-                                          -- 'performEvent', so that actions
-                                          -- (e.g., IO actions) can be run when
-                                          -- 'Event's fire.
-
-        flip runPostBuildT postBuild $    -- Allows the guest app to access to
-                                          -- a "post-build" 'Event'
-
-          flip runTriggerEventT events $  -- Allows the guest app to create new
-                                          -- events and triggers and write
-                                          -- those triggers to a channel from
-                                          -- which they will be read and
-                                          -- processed.
-            guest
-
-    -- Read the trigger reference for the post-build event. This will be
-    -- 'Nothing' if the guest application hasn't subscribed to this event.
+    -- Fold used for the post-build frame and for every event frame: stop as
+    -- soon as the guest's shutdown 'Event' fires, otherwise keep draining.
+    let untilShutdown handle () = do
+          mExit <- sequence =<< readEvent handle
+          pure $ maybe (Right ()) Left mExit
+    -- Build the guest network. 'subscribeEvent' yields the shutdown handle; the
+    -- build settle observes nothing, since the post-build event has not fired.
+    (_, shutdownEventHandle, _, fc) <- hostPerformEventTAndRead
+          ( flip runPostBuildT postBuild   -- guest can access the post-build 'Event'
+          . flip runTriggerEventT events   -- guest can create triggers, queued to 'events'
+          $ guest )
+          subscribeEvent
+          ()
+          untilShutdown
+    -- Read the post-build trigger. 'Nothing' if the guest never subscribed.
     mPostBuildTrigger <- readRef postBuildTriggerRef
-
-    -- Subscribe to an 'Event' of that the guest application can use to
-    -- request application shutdown. We'll check whether this 'Event' is firing
-    -- to determine whether to terminate. Subscribing requires a frame of its
-    -- own here; it precedes the post-build frame below either way.
-    shutdown <- runHostFrame $ subscribeEvent result
-
-    -- When there is a subscriber to the post-build event, fire the event.
-    initialShutdownEventFirings :: Maybe [Maybe a] <- for mPostBuildTrigger $ \postBuildTrigger ->
-      fire [postBuildTrigger :=> Identity ()] $ sequence =<< readEvent shutdown
-    let shutdownImmediately = case initialShutdownEventFirings of
-          -- We didn't even fire postBuild because it wasn't subscribed
-          Nothing -> Nothing
-          -- Take the first Just, if there is one. Ideally, we should cut off
-          -- the event loop as soon as the firing happens, but Performable
-          -- doesn't currently give us an easy way to do that
-          Just firings -> asum firings
-
+    -- Fire the post-build event as the first frame (when subscribed), draining
+    -- its performEvent cascade and aborting the moment the shutdown 'Event' fires.
+    shutdownImmediately <- case mPostBuildTrigger of
+      Nothing -> pure (Right ())
+      Just postBuildTrigger ->
+        runFireCommandAndRead fc [postBuildTrigger :=> Identity ()] () (untilShutdown shutdownEventHandle)
     case shutdownImmediately of
-      Just exitResult -> pure exitResult
-      -- The main application loop. We wait for new events and fire those that
-      -- have subscribers. If we detect a shutdown request, the application
-      -- terminates.
-      Nothing -> fix $ \loop -> do
-        -- Read the next event (blocking).
+      Left exitResult -> pure exitResult
+      -- Main loop: block for the next external event, fire it, and drain --
+      -- aborting the moment the shutdown 'Event' fires.
+      Right () -> fix $ \loop -> do
         ers <- liftIO $ readChan events
-        shutdownEventFirings :: [Maybe a] <- do
-          -- Fire events that have subscribers.
-          fireEventTriggerRefs fc ers $
-            -- Check if the shutdown 'Event' is firing.
-            sequence =<< readEvent shutdown
-        let -- If the shutdown event fires multiple times, take the first one.
-            -- Ideally, we should cut off the event loop as soon as this fires,
-            -- but Performable doesn't currently give us an easy way to do that.
-            shutdownNow = asum shutdownEventFirings
-        case shutdownNow of
-          Just exitResult -> pure exitResult
-          Nothing -> loop
-  where
-    -- Use the given 'FireCommand' to fire events that have subscribers
-    -- and call the callback for the 'TriggerInvocation' of each.
-    fireEventTriggerRefs
-      :: forall b m t
-      .  MonadIO m
-      => FireCommand t m
-      -> [DSum (EventTriggerRef t) TriggerInvocation]
-      -> ReadPhase m b
-      -> m [b]
-    fireEventTriggerRefs (FireCommand fire) ers rcb = do
-      mes <- liftIO $
-        for ers $ \(EventTriggerRef er :=> TriggerInvocation a _) -> do
-          me <- readIORef er
-          pure $ fmap (==> a) me
-      a <- fire (catMaybes mes) rcb
-      liftIO $ for_ ers $ \(_ :=> TriggerInvocation _ cb) -> cb
-      pure a
+        mes <- liftIO $
+          for ers $ \(EventTriggerRef er :=> TriggerInvocation a _) -> do
+            me <- readIORef er
+            pure $ fmap (==> a) me
+        mExit <- runFireCommandAndRead fc (catMaybes mes) () (untilShutdown shutdownEventHandle)
+        liftIO $ for_ ers $ \(_ :=> TriggerInvocation _ cb) -> cb
+        either pure (const loop) mExit

--- a/src/Reflex/Network.hs
+++ b/src/Reflex/Network.hs
@@ -15,15 +15,14 @@ module Reflex.Network
 import Reflex.Class
 import Reflex.Adjustable.Class
 import Reflex.NotReady.Class
-import Reflex.PostBuild.Class
 
 -- | A 'Dynamic' "network": Takes a 'Dynamic' of network-creating actions and replaces the network whenever the 'Dynamic' updates.
 -- The returned Event of network results fires at post-build time and when the 'Dynamic' updates.
 -- Note:  Often, the type 'a' is an Event, in which case the return value is an Event-of-Events, where the outer 'Event' fires
 -- when switching networks. Such an 'Event' would typically be flattened (via 'switchHoldPromptly').
-networkView :: (NotReady t m, Adjustable t m, PostBuild t m) => Dynamic t (m a) -> m (Event t a)
+networkView :: (NotReady t m, Adjustable t m, MonadHold t m) => Dynamic t (m a) -> m (Event t a)
 networkView child = do
-  postBuild <- getPostBuild
+  postBuild <- now
   let newChild = leftmost [updated child, tagCheap (current child) postBuild]
   snd <$> runWithReplace notReady newChild
 
@@ -37,7 +36,7 @@ networkHold child0 newChild = do
 
 -- | Render a placeholder network to be shown while another network is not yet
 -- done building
-untilReady :: (Adjustable t m, PostBuild t m) => m a -> m b -> m (a, Event t b)
+untilReady :: (Adjustable t m, MonadHold t m) => m a -> m b -> m (a, Event t b)
 untilReady a b = do
-  postBuild <- getPostBuild
+  postBuild <- now
   runWithReplace a $ b <$ postBuild

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -19,6 +19,8 @@
 module Reflex.PerformEvent.Base
   ( PerformEventT (..)
   , FireCommand (..)
+  , runFireCommand
+  , hostPerformEventTAndRead
   , hostPerformEventT
   ) where
 
@@ -29,6 +31,7 @@ import Reflex.PerformEvent.Class
 import Reflex.Requester.Base
 import Reflex.Requester.Class
 
+import Control.Monad (void)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Exception
 import Control.Monad.Fix
@@ -48,11 +51,24 @@ import qualified Data.Semigroup as S
 import Control.Monad.Identity
 #endif
 
--- | A function that fires events for the given 'EventTrigger's and then runs
--- any followup actions provided via 'PerformEvent'.  The given 'ReadPhase'
--- action will be run once for the initial trigger execution as well as once for
--- each followup.
-newtype FireCommand t m = FireCommand { runFireCommand :: forall a. [DSum (EventTrigger t) Identity] -> ReadPhase m a -> m [a] } --TODO: The handling of this ReadPhase seems wrong, or at least inelegant; how do we actually make the decision about what order frames run in?
+-- | Fires events for the given 'EventTrigger's and then folds the caller's step
+-- function over every resulting frame. Multiple frames can occur due to
+-- 'Reflex.Performevent.Class.PerformEvent.performEvent' feeding back new occurrences.
+--
+-- The caller is able to exit early by returning @Left <exitValue>@, after which
+-- no more effects are performed.
+newtype FireCommand t m = FireCommand
+  { runFireCommandAndRead
+      :: forall stop acc
+      .  [DSum (EventTrigger t) Identity]
+      -> acc
+      -> (acc -> ReadPhase m (Either stop acc))
+      -> m (Either stop acc)
+  }
+
+-- | Like 'runFireCommandAndRead', but without reading any events.
+runFireCommand :: MonadReflexHost t m => FireCommand t m -> [DSum (EventTrigger t) Identity] -> m ()
+runFireCommand fc triggers = void $ runFireCommandAndRead fc triggers () (\_ -> pure $ Right ())
 
 -- | Provides a basic implementation of 'PerformEvent'.  Note that, despite the
 -- name, 'PerformEventT' is not an instance of 'MonadTrans'.
@@ -120,9 +136,81 @@ instance ReflexHost t => MonadReflexCreateTrigger t (PerformEventT t m) where
   {-# INLINABLE newFanEventWithTrigger #-}
   newFanEventWithTrigger f = PerformEventT $ lift $ newFanEventWithTrigger f
 
--- | Run a 'PerformEventT' action, returning a 'FireCommand' that allows the
--- caller to trigger 'Event's while ensuring that 'performEvent' actions are run
--- at the appropriate time.
+-- | Handles the frame lifecycle for a 'PerformEventT' program.
+--
+-- * At t₀, the host-setup function is run, and any initial 'Performable'
+--   actions are evaluated outside of Reflex-time.
+--
+-- * At t₁, the results are fed back as occurrences to the 'performEvent' result
+--   events.
+--
+-- * If these result occurrences produce more 'Performable' actions, these are
+--   fed back as new occurrences at t₂, and so on, until no more actions are
+--   produced.
+--
+-- If 'Performable' occurrences happen after the initial settle, the same loop
+-- repeats. It returns the setup results, the folded observation of the frame-0
+-- settle, and a 'FireCommand' for subsequent frames.
+
+{-# INLINABLE hostPerformEventTAndRead #-}
+hostPerformEventTAndRead :: forall t m a b acc0 stop0.
+                     ( MonadReflexHost t m
+                     , MonadRef m
+                     , Ref m ~ Ref IO
+                     )
+                  => PerformEventT t m a
+                  -> (a -> HostFrame t b)
+                  -- ^ Setup on the t₀ result (e.g. do 'subscribeEvent' here).
+                  -> acc0
+                  -- ^ Initial value for the fold over the Perform-loop.
+                  -> (b -> acc0 -> ReadPhase m (Either stop0 acc0))
+                  -- ^ Perform-loop fold function.
+                  -> m (a, b, Either stop0 acc0, FireCommand t m)
+hostPerformEventTAndRead builder initialHostFrame seed step0 = do
+  (response, responseTrigger) <- newEventWithTriggerRef
+  let
+    readStep :: forall stop' acc'
+             .  EventHandle t (RequesterData (HostFrame t))
+             -> (acc' -> ReadPhase m (Either stop' acc'))
+             -> acc'
+             -> ReadPhase m (Either stop' acc', Maybe (RequesterData (HostFrame t)))
+    readStep perfHandle step acc = do
+      ds <- step acc
+      more <- sequence =<< readEvent perfHandle
+      pure (ds, more)
+    -- Fold the step across the cascade until it aborts or the cascade quiesces.
+    drain :: forall stop' acc'
+          .  EventHandle t (RequesterData (HostFrame t))
+          -> (acc' -> ReadPhase m (Either stop' acc'))
+          -> (Either stop' acc', Maybe (RequesterData (HostFrame t)))
+          -> m (Either stop' acc')
+    drain _ _ (Left stop, _) = pure $ Left stop
+    drain _ _ (Right acc, Nothing) = pure $ Right acc
+    drain perfHandle step (Right acc, Just toPerform) =
+      drain perfHandle step =<< do
+        mrt <- readRef responseTrigger
+        hostFrameAndRead
+          (traverseRequesterData (fmap Identity) toPerform)
+          (\responses -> pure $ maybe [] (\rt -> [rt :=> Identity responses]) mrt)
+          (const (readStep perfHandle step acc))
+  (a, b, perfHandle, frame0) <- hostFrameAndRead
+    (do (result, eventToPerform) <- runRequesterT (unPerformEventT builder) response
+        perfHandle' :: EventHandle t (RequesterData (HostFrame t)) <- subscribeEvent eventToPerform
+        b' <- initialHostFrame result
+        pure (result, b', perfHandle'))
+    (const (pure []))
+    (\(result, b', perfHandle') -> (,,,) result b' perfHandle' <$> readStep perfHandle' (step0 b') seed)
+  t0result <- drain perfHandle (step0 b) frame0
+  pure
+    ( a
+    , b
+    , t0result
+    , FireCommand $ \triggers v step ->
+        drain perfHandle step =<< fireEventsAndRead triggers (readStep perfHandle step v)
+    )
+
+-- | Like 'hostPerformEventTAndRead', but without observing the frame in which
+-- the network is built.
 {-# INLINABLE hostPerformEventT #-}
 hostPerformEventT :: forall t m a.
                      ( MonadReflexHost t m
@@ -131,29 +219,9 @@ hostPerformEventT :: forall t m a.
                      )
                   => PerformEventT t m a
                   -> m (a, FireCommand t m)
-hostPerformEventT a = do
-  (response, responseTrigger) <- newEventWithTriggerRef
-  (result, eventToPerformHandle) <- runHostFrame $ do
-    (result, eventToPerform) <- runRequesterT (unPerformEventT a) response
-    handle <- subscribeEvent eventToPerform
-    pure (result, handle)
-  return $ (,) result $ FireCommand $ \triggers (readPhase :: ReadPhase m a') -> do
-    let go :: [DSum (EventTrigger t) Identity] -> m [a']
-        go ts = do
-          (result', mToPerform) <- fireEventsAndRead ts $ do
-            mToPerform <- sequence =<< readEvent eventToPerformHandle
-            result' <- readPhase
-            return (result', mToPerform)
-          case mToPerform of
-            Nothing -> return [result']
-            Just toPerform -> do
-              responses <- runHostFrame $ traverseRequesterData (fmap Identity) toPerform
-              mrt <- readRef responseTrigger
-              let followupEventTriggers = case mrt of
-                    Just rt -> [rt :=> Identity responses]
-                    Nothing -> []
-              (result':) <$> go followupEventTriggers
-    go triggers
+hostPerformEventT builder = do
+  (a, _, _, fc) <- hostPerformEventTAndRead builder (const $ pure ()) () (\_ _ -> pure $ Right ())
+  pure (a, fc)
 
 instance ReflexHost t => MonadSample t (PerformEventT t m) where
   {-# INLINABLE sample #-}

--- a/src/Reflex/PerformEvent/Base.hs
+++ b/src/Reflex/PerformEvent/Base.hs
@@ -133,8 +133,10 @@ hostPerformEventT :: forall t m a.
                   -> m (a, FireCommand t m)
 hostPerformEventT a = do
   (response, responseTrigger) <- newEventWithTriggerRef
-  (result, eventToPerform) <- runHostFrame $ runRequesterT (unPerformEventT a) response
-  eventToPerformHandle <- subscribeEvent eventToPerform
+  (result, eventToPerformHandle) <- runHostFrame $ do
+    (result, eventToPerform) <- runRequesterT (unPerformEventT a) response
+    handle <- subscribeEvent eventToPerform
+    pure (result, handle)
   return $ (,) result $ FireCommand $ \triggers (readPhase :: ReadPhase m a') -> do
     let go :: [DSum (EventTrigger t) Identity] -> m [a']
         go ts = do
@@ -157,7 +159,7 @@ instance ReflexHost t => MonadSample t (PerformEventT t m) where
   {-# INLINABLE sample #-}
   sample = PerformEventT . lift . sample
 
-instance (ReflexHost t, MonadHold t m) => MonadHold t (PerformEventT t m) where
+instance ReflexHost t => MonadHold t (PerformEventT t m) where
   {-# INLINABLE hold #-}
   hold v0 v' = PerformEventT $ lift $ hold v0 v'
   {-# INLINABLE holdDyn #-}

--- a/src/Reflex/PostBuild/Base.hs
+++ b/src/Reflex/PostBuild/Base.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -14,9 +13,6 @@
 module Reflex.PostBuild.Base
   ( PostBuildT (..)
   , runPostBuildT
-  -- * Internal
-  , mapIntMapWithAdjustImpl
-  , mapDMapWithAdjustImpl
   ) where
 
 import Control.Monad.Catch (MonadMask, MonadThrow, MonadCatch)
@@ -26,11 +22,6 @@ import Control.Monad.Primitive
 import Control.Monad.Reader
 import Control.Monad.Ref
 import qualified Control.Monad.Trans.Control as TransControl
-import Data.Dependent.Map (DMap)
-import qualified Data.Dependent.Map as DMap
-import Data.Functor.Compose
-import Data.IntMap.Strict (IntMap)
-import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Semigroup as S
 
 #if !MIN_VERSION_base(4,18,0)
@@ -44,16 +35,16 @@ import Reflex.Host.Class
 import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Class
 import Reflex.TriggerEvent.Class
+import Data.Coerce (coerce)
 
 -- | Provides a basic implementation of 'PostBuild'.
-newtype PostBuildT t m a = PostBuildT { unPostBuildT :: ReaderT (Event t ()) m a }
+newtype PostBuildT t m a = PostBuildT { unPostBuildT :: m a }
   deriving
     ( Functor
     , Applicative
     , Monad
     , MonadFix
     , MonadIO
-    , MonadTrans
     , MonadException
     , MonadAsyncException
     , MonadMask
@@ -61,12 +52,15 @@ newtype PostBuildT t m a = PostBuildT { unPostBuildT :: ReaderT (Event t ()) m a
     , MonadCatch
     )
 
+instance MonadTrans (PostBuildT t) where
+  lift = PostBuildT
+
 -- | Run a 'PostBuildT' action.  An 'Event' should be provided that fires
 -- immediately after the action is finished running; no other 'Event's should
 -- fire first.
 {-# INLINABLE runPostBuildT #-}
-runPostBuildT :: PostBuildT t m a -> Event t () -> m a
-runPostBuildT (PostBuildT a) = runReaderT a
+runPostBuildT :: PostBuildT t m a -> m a
+runPostBuildT = unPostBuildT
 
 -- TODO: Monoid and Semigroup can likely be derived once ReaderT has them.
 instance (Monoid a, Applicative m) => Monoid (PostBuildT t m a) where
@@ -79,9 +73,9 @@ instance PrimMonad m => PrimMonad (PostBuildT x m) where
   type PrimState (PostBuildT x m) = PrimState m
   primitive = lift . primitive
 
-instance (Reflex t, Monad m) => PostBuild t (PostBuildT t m) where
+instance (Reflex t, MonadHold t m, Monad m) => PostBuild t (PostBuildT t m) where
   {-# INLINABLE getPostBuild #-}
-  getPostBuild = PostBuildT ask
+  getPostBuild = PostBuildT now
 
 instance MonadSample t m => MonadSample t (PostBuildT t m) where
   {-# INLINABLE sample #-}
@@ -110,9 +104,9 @@ instance PerformEvent t m => PerformEvent t (PostBuildT t m) where
 
 instance (ReflexHost t, MonadReflexCreateTrigger t m) => MonadReflexCreateTrigger t (PostBuildT t m) where
   {-# INLINABLE newEventWithTrigger #-}
-  newEventWithTrigger = PostBuildT . lift . newEventWithTrigger
+  newEventWithTrigger = PostBuildT . newEventWithTrigger
   {-# INLINABLE newFanEventWithTrigger #-}
-  newFanEventWithTrigger f = PostBuildT $ lift $ newFanEventWithTrigger f
+  newFanEventWithTrigger f = PostBuildT $ newFanEventWithTrigger f
 
 instance TriggerEvent t m => TriggerEvent t (PostBuildT t m) where
   {-# INLINABLE newTriggerEvent #-}
@@ -135,70 +129,16 @@ instance MonadAtomicRef m => MonadAtomicRef (PostBuildT t m) where
   atomicModifyRef r = lift . atomicModifyRef r
 
 instance (Reflex t, MonadHold t m, MonadFix m, Adjustable t m, PerformEvent t m) => Adjustable t (PostBuildT t m) where
-  runWithReplace a0 a' = do
-    postBuild <- getPostBuild
-    lift $ do
-      rec result@(_, result') <- runWithReplace (runPostBuildT a0 postBuild) $ fmap (\v -> runPostBuildT v =<< headE voidResult') a'
-          let voidResult' = fmapCheap (\_ -> ()) result'
-      return result
+  runWithReplace a0 a' =
+    PostBuildT $ runWithReplace (coerce a0) (coerceEvent a')
   {-# INLINABLE traverseIntMapWithKeyWithAdjust #-}
-  traverseIntMapWithKeyWithAdjust = mapIntMapWithAdjustImpl traverseIntMapWithKeyWithAdjust
+  traverseIntMapWithKeyWithAdjust f dm0 dm' =
+    PostBuildT $ traverseIntMapWithKeyWithAdjust (\k v -> unPostBuildT (f k v)) dm0 dm'
   {-# INLINABLE traverseDMapWithKeyWithAdjust #-}
-  traverseDMapWithKeyWithAdjust = mapDMapWithAdjustImpl traverseDMapWithKeyWithAdjust mapPatchDMap
-  traverseDMapWithKeyWithAdjustWithMove = mapDMapWithAdjustImpl traverseDMapWithKeyWithAdjustWithMove mapPatchDMapWithMove
-
-{-# INLINABLE mapIntMapWithAdjustImpl #-}
-mapIntMapWithAdjustImpl :: forall t m v v' p. (Reflex t, MonadFix m, MonadHold t m, Functor p)
-  => (   (IntMap.Key -> (Event t (), v) -> m v')
-      -> IntMap (Event t (), v)
-      -> Event t (p (Event t (), v))
-      -> m (IntMap v', Event t (p v'))
-     )
-  -> (IntMap.Key -> v -> PostBuildT t m v')
-  -> IntMap v
-  -> Event t (p v)
-  -> PostBuildT t m (IntMap v', Event t (p v'))
-mapIntMapWithAdjustImpl base f dm0 dm' = do
-  postBuild <- getPostBuild
-  let loweredDm0 = fmap ((,) postBuild) dm0
-      f' :: IntMap.Key -> (Event t (), v) -> m v'
-      f' k (e, v) = do
-        runPostBuildT (f k v) e
-  lift $ do
-    rec (result0, result') <- base f' loweredDm0 loweredDm'
-        cohortDone <- numberOccurrencesFrom_ 1 result'
-        numberedDm' <- numberOccurrencesFrom 1 dm'
-        let postBuild' = fanInt $ fmapCheap (`IntMap.singleton` ()) cohortDone
-            loweredDm' = flip pushAlways numberedDm' $ \(n, p) -> do
-              return $ fmap ((,) (selectInt postBuild' n)) p
-    return (result0, result')
-
-{-# INLINABLE mapDMapWithAdjustImpl #-}
-mapDMapWithAdjustImpl :: forall t m k v v' p. (Reflex t, MonadFix m, MonadHold t m)
-  => (   (forall a. k a -> Compose ((,) (Bool, Event t ())) v a -> m (v' a))
-      -> DMap k (Compose ((,) (Bool, Event t ())) v)
-      -> Event t (p k (Compose ((,) (Bool, Event t ())) v))
-      -> m (DMap k v', Event t (p k v'))
-     )
-  -> ((forall a. v a -> Compose ((,) (Bool, Event t ())) v a) -> p k v -> p k (Compose ((,) (Bool, Event t ())) v))
-  -> (forall a. k a -> v a -> PostBuildT t m (v' a))
-  -> DMap k v
-  -> Event t (p k v)
-  -> PostBuildT t m (DMap k v', Event t (p k v'))
-mapDMapWithAdjustImpl base mapPatch f dm0 dm' = do
-  postBuild <- getPostBuild
-  let loweredDm0 = DMap.map (Compose . (,) (False, postBuild)) dm0
-      f' :: forall a. k a -> Compose ((,) (Bool, Event t ())) v a -> m (v' a)
-      f' k (Compose ((shouldHeadE, e), v)) = do
-        eOnce <- if shouldHeadE
-          then headE e --TODO: Avoid doing this headE so many times; once per loweredDm' firing ought to be OK, but it's not totally trivial to do because result' might be firing at the same time, and we don't want *that* to be the postBuild occurrence
-          else return e
-        runPostBuildT (f k v) eOnce
-  lift $ do
-    rec (result0, result') <- base f' loweredDm0 loweredDm'
-        let voidResult' = fmapCheap (\_ -> ()) result'
-        let loweredDm' = ffor dm' $ mapPatch (Compose . (,) (True, voidResult'))
-    return (result0, result')
+  traverseDMapWithKeyWithAdjust f dm0 dm' =
+    PostBuildT $ traverseDMapWithKeyWithAdjust (\k v -> unPostBuildT (f k v)) dm0 dm'
+  traverseDMapWithKeyWithAdjustWithMove f dm0 dm' =
+    PostBuildT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> unPostBuildT (f k v)) dm0 dm'
 
 --------------------------------------------------------------------------------
 -- Deprecated functionality
@@ -206,8 +146,8 @@ mapDMapWithAdjustImpl base mapPatch f dm0 dm' = do
 
 -- | Deprecated
 instance TransControl.MonadTransControl (PostBuildT t) where
-  type StT (PostBuildT t) a = TransControl.StT (ReaderT (Event t ())) a
+  type StT (PostBuildT t) a = a
   {-# INLINABLE liftWith #-}
-  liftWith = TransControl.defaultLiftWith PostBuildT unPostBuildT
+  liftWith f = PostBuildT $ f unPostBuildT
   {-# INLINABLE restoreT #-}
-  restoreT = TransControl.defaultRestoreT PostBuildT
+  restoreT = PostBuildT

--- a/src/Reflex/PostBuild/Class.hs
+++ b/src/Reflex/PostBuild/Class.hs
@@ -24,15 +24,15 @@ import qualified Control.Monad.State.Strict as Strict
 -- 'Behavior's and 'Dynamic's to be safely sampled, regardless of where they
 -- were created, when the post-build 'Event' fires.  The post-build 'Event' will
 -- fire exactly once for an given action.
-class (Reflex t, Monad m) => PostBuild t m | m -> t where
+class (Reflex t, Monad m, MonadHold t m) => PostBuild t m | m -> t where
   -- | Retrieve the post-build 'Event' for this action.
   getPostBuild :: m (Event t ())
 
 instance PostBuild t m => PostBuild t (ReaderT r m) where
-  getPostBuild = lift getPostBuild
+  getPostBuild = now
 
-instance PostBuild t m => PostBuild t (StateT s m) where
-  getPostBuild = lift getPostBuild
+instance (Reflex t, MonadHold t m) => PostBuild t (StateT s m) where
+  getPostBuild = now
 
 instance PostBuild t m => PostBuild t (Strict.StateT s m) where
-  getPostBuild = lift getPostBuild
+  getPostBuild = now

--- a/src/Reflex/Profiled.hs
+++ b/src/Reflex/Profiled.hs
@@ -280,8 +280,7 @@ instance PrimMonad m => PrimMonad (ProfiledM m) where
 
 instance MonadReflexHost t m => MonadReflexHost (ProfiledTimeline t) (ProfiledM m) where
   type ReadPhase (ProfiledM m) = ProfiledM (ReadPhase m)
-  fireEventsAndRead ts r = lift $ fireEventsAndRead ts $ coerce r
-  runHostFrame = lift . runHostFrame . coerce
+  hostFrameAndRead build getTriggers readPhase = lift $ hostFrameAndRead (coerce build) (runProfiledM . getTriggers) (runProfiledM . readPhase)
 
 instance MonadReadEvent t m => MonadReadEvent (ProfiledTimeline t) (ProfiledM m) where
   readEvent = lift . fmap coerce . readEvent

--- a/src/Reflex/Query/Base.hs
+++ b/src/Reflex/Query/Base.hs
@@ -291,7 +291,7 @@ instance (S.Semigroup a, Monad m) => S.Semigroup (QueryT t q m a) where
   (<>) = liftA2 (S.<>)
 
 -- | withQueryT's QueryMorphism argument needs to be a group homomorphism in order to behave correctly
-withQueryT :: (MonadHold t m, PostBuild t m, Group q, Group q', Commutative q, Commutative q', Query q')
+withQueryT :: (Reflex t, MonadHold t m, Group q, Group q', Commutative q, Commutative q', Query q')
            => QueryMorphism q q'
            -> QueryT t q m a
            -> QueryT t q' m a
@@ -308,7 +308,7 @@ mapQueryT :: (forall b. m b -> n b) -> QueryT t q m a -> QueryT t q n a
 mapQueryT f (QueryT a) = QueryT $ mapStateT (mapEventWriterT (mapReaderT f)) a
 
 -- | dynWithQueryT's (Dynamic t QueryMorphism) argument needs to be a group homomorphism at all times in order to behave correctly
-dynWithQueryT :: (MonadHold t m, PostBuild t m, Group q, Commutative q, Group q', Commutative q', Query q')
+dynWithQueryT :: (Reflex t, MonadHold t m, Group q, Commutative q, Group q', Commutative q', Query q')
            => Dynamic t (QueryMorphism q q')
            -> QueryT t q m a
            -> QueryT t q' m a

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -61,7 +61,7 @@ import Data.Proxy
 import Data.These
 import Data.Traversable
 import Data.Type.Equality ((:~:)(Refl))
-import GHC.Exts hiding (toList)
+import GHC.Exts hiding (toList, build)
 import GHC.IORef (IORef (..))
 import GHC.Stack
 import Reflex.FastWeak
@@ -1392,12 +1392,11 @@ coincidence a = unsafePerformIO $ do
     , coincidenceSubscribed = ref
     }
 
--- Propagate the given event occurrence; before cleaning up, run the given action, which may read the state of events and behaviors
-run :: forall x b. HasSpiderTimeline x => [DSum (RootTrigger x) Identity] -> ResultM x b -> SpiderHost x b
-run roots after = do
-  tracePropagate (Proxy :: Proxy x) $ "Running an event frame with " <> show (length roots) <> " events"
-  let t = spiderTimeline :: SpiderTimelineEnv x
-  result <- SpiderHost $ withMVar (_spiderTimeline_lock (unSTE t)) $ \_ -> unSpiderHost $ runFrame $ do
+-- | Propagate root triggers and process delayed merges, then run the
+-- given read action. Runs inside the single 'runFrame' of
+-- 'runHostFrameFireAndRead', after the build and hold-init phases.
+propagateAndRead :: forall x b. HasSpiderTimeline x => [DSum (RootTrigger x) Identity] -> ResultM x b -> EventM x b
+propagateAndRead roots after = do
     rootsToPropagate <- forM roots $ \r@(RootTrigger (_, occRef, k) :=> a) -> do
       occBefore <- liftIO $ do
         occBefore <- readIORef occRef
@@ -1423,8 +1422,6 @@ run roots after = do
     go
     putCurrentHeight maxBound
     after
-  tracePropagate (Proxy :: Proxy x) "Done running an event frame"
-  return result
 
 scheduleMerge' :: HasSpiderTimeline x => Height -> IORef Height -> EventM x () -> EventM x ()
 scheduleMerge' initialHeight heightRef a = scheduleMerge initialHeight $ do
@@ -2744,13 +2741,11 @@ instance HasSpiderTimeline x => Reflex.Host.Class.MonadSubscribeEvent (SpiderTim
   subscribeEvent e = SpiderHostFrame $ do
     --TODO: Unsubscribe eventually (manually and/or with weak ref)
     val <- liftIO $ newIORef Nothing
-    subscription <- subscribe (unSpiderEvent e) $ Subscriber
-      { subscriberPropagate = \a -> do
+    let recordOccurrence a = do
           liftIO $ writeIORef val $ Just a
           scheduleClear val
-      , subscriberInvalidateHeight = \_ -> return ()
-      , subscriberRecalculateHeight = \_ -> return ()
-      }
+    (subscription, occ) <- subscribeAndRead (unSpiderEvent e) $ terminalSubscriber recordOccurrence
+    forM_ occ recordOccurrence
     return $ SpiderEventHandle
       { spiderEventHandleSubscription = subscription
       , spiderEventHandleValue = val
@@ -2782,8 +2777,17 @@ instance HasSpiderTimeline x => Reflex.Host.Class.MonadReflexCreateTrigger (Spid
 
 instance HasSpiderTimeline x => Reflex.Host.Class.MonadReflexHost (SpiderTimeline x) (SpiderHost x) where
   type ReadPhase (SpiderHost x) = Reflex.Spider.Internal.ReadPhase x
-  fireEventsAndRead es (Reflex.Spider.Internal.ReadPhase a) = run es a
-  runHostFrame = runFrame . runSpiderHostFrame
+  hostFrameAndRead build getTriggers readPhase = runHostFrameFireAndRead (runSpiderHostFrame build) (runSpiderHostFrame . getTriggers) (\a -> let Reflex.Spider.Internal.ReadPhase r = readPhase a in r)
+
+runHostFrameFireAndRead :: forall x a b. HasSpiderTimeline x => EventM x a -> (a -> EventM x [DSum (RootTrigger x) Identity]) -> (a -> ResultM x b) -> SpiderHost x b
+runHostFrameFireAndRead build getTriggers readPhase = do
+  let t = spiderTimeline :: SpiderTimelineEnv x
+  SpiderHost $ withMVar (_spiderTimeline_lock (unSTE t)) $ \_ -> unSpiderHost $ runFrame $ do
+    a <- build
+    env <- asksEventEnv id
+    runHoldInits (eventEnvHoldInits env) (eventEnvDynInits env) (eventEnvMergeInits env)
+    roots <- getTriggers a
+    propagateAndRead roots (readPhase a)
 
 unsafeNewSpiderTimelineEnv :: forall x. IO (SpiderTimelineEnv x)
 unsafeNewSpiderTimelineEnv = do

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -2697,21 +2697,6 @@ holdIncrementalSpiderEventM v0 e = fmap (SpiderIncremental . dynamicHold) $ Refl
 buildDynamicSpiderEventM :: HasSpiderTimeline x => SpiderPushM x a -> Reflex.Class.Event (SpiderTimeline x) a -> EventM x (Reflex.Class.Dynamic (SpiderTimeline x) a)
 buildDynamicSpiderEventM getV0 e = fmap (SpiderDynamic . dynamicDynIdentity) $ Reflex.Spider.Internal.buildDynamic (coerce getV0) $ coerce $ unSpiderEvent e
 
-instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (SpiderHost x) where
-  {-# INLINABLE hold #-}
-  hold v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.hold v0 e
-  {-# INLINABLE holdDyn #-}
-  holdDyn v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdDyn v0 e
-  {-# INLINABLE holdIncremental #-}
-  holdIncremental v0 e = runFrame . runSpiderHostFrame $ Reflex.Class.holdIncremental v0 e
-  {-# INLINABLE buildDynamic #-}
-  buildDynamic getV0 e = runFrame . runSpiderHostFrame $ Reflex.Class.buildDynamic getV0 e
-  {-# INLINABLE headE #-}
-  headE e = runFrame . runSpiderHostFrame $ Reflex.Class.headE e
-  {-# INLINABLE now #-}
-  now = runFrame . runSpiderHostFrame $ Reflex.Class.now
-
-
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHostFrame x) where
   sample = SpiderHostFrame . readBehaviorUntracked . unSpiderBehavior --TODO: This can cause problems with laziness, so we should get rid of it if we can
 
@@ -2728,10 +2713,6 @@ instance HasSpiderTimeline x => Reflex.Class.MonadHold (SpiderTimeline x) (Spide
   headE (SpiderEvent e) = SpiderHostFrame $ SpiderEvent <$> Reflex.Spider.Internal.headE e
   {-# INLINABLE now #-}
   now = SpiderHostFrame Reflex.Class.now
-
-instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (SpiderHost x) where
-  {-# INLINABLE sample #-}
-  sample = runFrame . readBehaviorUntracked . unSpiderBehavior
 
 instance HasSpiderTimeline x => Reflex.Class.MonadSample (SpiderTimeline x) (Reflex.Spider.Internal.ReadPhase x) where
   {-# INLINABLE sample #-}
@@ -2798,10 +2779,6 @@ instance HasSpiderTimeline x => Reflex.Host.Class.MonadReflexCreateTrigger (Spid
   newFanEventWithTrigger f = SpiderHostFrame $ EventM $ liftIO $ do
     es <- newFanEventWithTriggerIO f
     return $ Reflex.Class.EventSelector $ SpiderEvent . Reflex.Spider.Internal.select es
-
-instance HasSpiderTimeline x => Reflex.Host.Class.MonadSubscribeEvent (SpiderTimeline x) (SpiderHost x) where
-  {-# INLINABLE subscribeEvent #-}
-  subscribeEvent = runFrame . runSpiderHostFrame . Reflex.Host.Class.subscribeEvent
 
 instance HasSpiderTimeline x => Reflex.Host.Class.MonadReflexHost (SpiderTimeline x) (SpiderHost x) where
   type ReadPhase (SpiderHost x) = Reflex.Spider.Internal.ReadPhase x

--- a/src/Reflex/Time.hs
+++ b/src/Reflex/Time.hs
@@ -38,7 +38,6 @@ import Data.Semigroup (Semigroup(..))
 import Reflex.Class
 import Reflex.Dynamic
 import Reflex.PerformEvent.Class
-import Reflex.PostBuild.Class
 import Reflex.TriggerEvent.Class
 
 -- | Metadata associated with a timer "tick"
@@ -55,14 +54,14 @@ data TickInfo
 -- | Fires an 'Event' once every time provided interval elapses, approximately.
 -- The provided 'UTCTime' is used bootstrap the determination of how much time has elapsed with each tick.
 -- This is a special case of 'tickLossyFrom' that uses the post-build event to start the tick thread.
-tickLossy :: (PostBuild t m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadFix m) => NominalDiffTime -> UTCTime -> m (Event t TickInfo)
-tickLossy dt t0 = tickLossyFrom dt t0 =<< getPostBuild
+tickLossy :: (MonadHold t m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadFix m) => NominalDiffTime -> UTCTime -> m (Event t TickInfo)
+tickLossy dt t0 = tickLossyFrom dt t0 =<< now
 
 -- | Fires an 'Event' once every time provided interval elapses, approximately.
 -- This is a special case of 'tickLossyFrom' that uses the post-build event to start the tick thread and the time of the post-build as the tick basis time.
-tickLossyFromPostBuildTime :: (PostBuild t m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadFix m) => NominalDiffTime -> m (Event t TickInfo)
+tickLossyFromPostBuildTime :: (MonadHold t m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadFix m) => NominalDiffTime -> m (Event t TickInfo)
 tickLossyFromPostBuildTime dt = do
-  postBuild <- getPostBuild
+  postBuild <- now
   postBuildTime <- performEvent $ liftIO getCurrentTime <$ postBuild
   tickLossyFrom' $ (dt,) <$> postBuildTime
 
@@ -98,7 +97,7 @@ tickLossyFrom' e = do
           cb (tick, pair)
 
 -- | Like 'tickLossy', but immediately calculates the first tick and provides a 'Dynamic' that is updated as ticks fire.
-clockLossy :: (MonadIO m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), PostBuild t m, MonadHold t m, MonadFix m) => NominalDiffTime -> UTCTime -> m (Dynamic t TickInfo)
+clockLossy :: (MonadIO m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadHold t m, MonadFix m) => NominalDiffTime -> UTCTime -> m (Dynamic t TickInfo)
 clockLossy dt t0 = do
   initial <- liftIO $ getCurrentTick dt t0
   e <- tickLossy dt t0
@@ -144,14 +143,14 @@ poissonLossyFrom rnd rate = inhomogeneousPoissonFrom rnd (constant rate) rate
 --   the current interval, with 0 representing the basis time.
 --   Automatically begin sending events when the DOM is built
 poissonLossy
-  :: (RandomGen g, MonadIO (Performable m), PerformEvent t m, TriggerEvent t m, PostBuild t m)
+  :: (RandomGen g, MonadIO (Performable m), PerformEvent t m, TriggerEvent t m, MonadHold t m)
   => g
   -> Double
   -- ^ Poisson event rate (Hz)
   -> UTCTime
   -- ^ Baseline time for events
   -> m (Event t TickInfo)
-poissonLossy rnd rate t0 = poissonLossyFrom rnd rate t0 =<< getPostBuild
+poissonLossy rnd rate t0 = poissonLossyFrom rnd rate t0 =<< now
 
 -- | Send events with inhomogeneous Poisson timing with the given basis
 --   and variable rate. Provide a maxRate that you expect to support.
@@ -211,14 +210,14 @@ inhomogeneousPoissonFrom rnd rate maxRate t0 e = do
 -- | Send events with inhomogeneous Poisson timing with the given basis
 --   and variable rate. Provide a maxRate that you expect to support
 inhomogeneousPoisson
-  :: (RandomGen g, MonadIO (Performable m), PerformEvent t m, TriggerEvent t m, PostBuild t m)
+  :: (RandomGen g, MonadIO (Performable m), PerformEvent t m, TriggerEvent t m, MonadHold t m)
   => g
   -> Behavior t Double
   -> Double
   -> UTCTime
   -> m (Event t TickInfo)
 inhomogeneousPoisson rnd rate maxRate t0 =
-  inhomogeneousPoissonFrom rnd rate maxRate t0 =<< getPostBuild
+  inhomogeneousPoissonFrom rnd rate maxRate t0 =<< now
 
 -- | Block occurrences of an Event until the given number of seconds elapses without
 --   the Event firing, at which point the last occurrence of the Event will fire.

--- a/src/Reflex/Workflow.hs
+++ b/src/Reflex/Workflow.hs
@@ -23,7 +23,6 @@ import Reflex.Class
 import Reflex.Adjustable.Class
 import Reflex.Network
 import Reflex.NotReady.Class
-import Reflex.PostBuild.Class
 
 -- | A widget in a workflow
 --
@@ -37,7 +36,7 @@ workflow w0 = do
   return $ fmap fst eResult
 
 -- | Similar to 'workflow', but outputs an 'Event' that fires at post-build time and whenever the current 'Workflow' is replaced by the next 'Workflow'.
-workflowView :: forall t m a. (NotReady t m, Adjustable t m, MonadFix m, MonadHold t m, PostBuild t m) => Workflow t m a -> m (Event t a)
+workflowView :: forall t m a. (NotReady t m, Adjustable t m, MonadFix m, MonadHold t m) => Workflow t m a -> m (Event t a)
 workflowView w0 = do
   rec eResult <- networkView . fmap unWorkflow =<< holdDyn w0 eReplace
       eReplace <- fmap switch $ hold never $ fmap snd eResult

--- a/test/GC.hs
+++ b/test/GC.hs
@@ -54,7 +54,7 @@ checkHeadEAtMostOnce = S.runSpiderHost $ do
   Just trigger <- liftIO $ readIORef inputTriggerRef
   Host.fireEvents [trigger :=> Identity "first"]
   liftIO performMajorGC
-  lateHandle <- Host.subscribeEvent headOfInput
+  lateHandle <- Host.runHostFrame $ Host.subscribeEvent headOfInput
   lateOccurrence <- Host.fireEventsAndRead [trigger :=> Identity "second"] $
     Host.readEvent lateHandle >>= \case
       Nothing -> return Nothing
@@ -92,7 +92,7 @@ hostPerf ref = S.runSpiderHost $ do
                $ S.pushCheap (return . Just . DMap.singleton Action . (\_ -> liftIO (writeIORef ref (Just 1)))) $ eadd)
       (flip S.pushCheap reqMap $ \m -> return $ Just $ mconcat $ (\(Const2 _ :=> Identity reqs) -> reqs) <$> DMap.toList m)
   ---- epilogue
-  eventToPerformHandle <- Host.subscribeEvent (S.SpiderEvent eventToPerform)
+  eventToPerformHandle <- Host.runHostFrame $ Host.subscribeEvent (S.SpiderEvent eventToPerform)
   liftIO $ putStrLn "#performing GC" >> performMajorGC
   liftIO $ putStrLn "#attempting to fire eadd"
   mAddTrigger <- readRef addTriggerRef

--- a/test/Reflex/Plan/Reflex.hs
+++ b/test/Reflex/Plan/Reflex.hs
@@ -86,20 +86,17 @@ instance (ReflexHost t, MonadRef (HostFrame t), Ref (HostFrame t) ~ Ref IO) => T
       makeFiring ref (t, a) = (fromIntegral t, [Firing ref a])
 
 
-firingTrigger :: (MonadReflexHost t m, MonadIORef m) => Firing t -> m (Maybe (DSum  (EventTrigger t) Identity))
-firingTrigger (Firing ref a) = fmap (:=> Identity a) <$> readRef ref
+firingTrigger :: (ReflexHost t, MonadIO m) => Firing t -> m (Maybe (DSum  (EventTrigger t) Identity))
+firingTrigger (Firing ref a) = liftIO $ fmap (:=> Identity a) <$> readIORef ref
 
 runPlan :: (MonadReflexHost t m) => Plan t a -> m (a, Schedule t)
 runPlan (Plan p) = runHostFrame $ runStateT p mempty
 
--- | Run a plan producing an event and subscribe to that event in the plan's
--- build frame.
 setupFiring :: (MonadReflexHost t m) => Plan t (Event t a) -> m (EventHandle t a, Schedule t)
 setupFiring (Plan p) = runHostFrame $ do
   (e, s) <- runStateT p mempty
   h <- subscribeEvent e
   return (h, s)
-
 
 makeDense :: Schedule t -> Schedule t
 makeDense s = fromMaybe (emptyRange 0) $ do
@@ -131,14 +128,29 @@ readEvent' = readEvent >=> sequenceA
 
 
 -- Convenience functions for running tests producing Events/Behaviors
+
+-- | Iterate the schedule for frames 1..n (frame 0 is handled separately
+-- by 'hostFrameAndRead').  'performGC' runs before each frame to match the
+-- old 'testSchedule' behaviour.
+testScheduleRest :: (MonadReflexHost t m, MonadIORef m, NFData a) => Schedule t -> ReadPhase m a -> m (IntMap a)
+testScheduleRest schedule readResult =
+  IntMap.traverseWithKey (\t occs -> liftIO performGC *> triggerFrame readResult t occs) (IntMap.delete 0 (makeDense schedule))
+
+runTest :: (MonadReflexHost t m, MonadIORef m, NFData b) => HostFrame t (Schedule t, a) -> (a -> ReadPhase m b) -> m (IntMap b)
+runTest build readResult = do
+  liftIO performGC
+  (s, a, frame0) <- hostFrameAndRead
+    build
+    (\(s, _) -> catMaybes <$> traverse firingTrigger (IntMap.findWithDefault [] 0 s))
+    (\(s, a) -> do v <- readResult a; pure (s, a, v))
+  frame0' <- liftIO . evaluate . force $ frame0
+  rest <- testScheduleRest s (readResult a)
+  pure $ IntMap.insert 0 frame0' rest
+
 runTestB :: (MonadReflexHost t m, MonadIORef m, NFData a) => Plan t (Behavior t a) -> m (IntMap a)
-runTestB p = do
-  (b, s) <- runPlan p
-  testSchedule s $ sample b
+runTestB (Plan p) = runTest (do (b, s) <- runStateT p mempty; pure (s, b)) sample
 
 runTestE :: (MonadReflexHost t m, MonadIORef m, NFData a) => Plan t (Event t a) -> m (IntMap (Maybe a))
-runTestE p = do
-  (h, s) <- setupFiring p
-  testSchedule s (readEvent' h)
+runTestE (Plan p) = runTest (do (e, s) <- runStateT p mempty; h <- subscribeEvent e; pure (s, h)) readEvent'
 
 

--- a/test/Reflex/Plan/Reflex.hs
+++ b/test/Reflex/Plan/Reflex.hs
@@ -11,6 +11,7 @@
 module Reflex.Plan.Reflex
   ( TestPlan(..)
   , runPlan
+  , setupFiring
   , Plan (..)
   , Schedule
   , Firing (..)
@@ -91,6 +92,14 @@ firingTrigger (Firing ref a) = fmap (:=> Identity a) <$> readRef ref
 runPlan :: (MonadReflexHost t m) => Plan t a -> m (a, Schedule t)
 runPlan (Plan p) = runHostFrame $ runStateT p mempty
 
+-- | Run a plan producing an event and subscribe to that event in the plan's
+-- build frame.
+setupFiring :: (MonadReflexHost t m) => Plan t (Event t a) -> m (EventHandle t a, Schedule t)
+setupFiring (Plan p) = runHostFrame $ do
+  (e, s) <- runStateT p mempty
+  h <- subscribeEvent e
+  return (h, s)
+
 
 makeDense :: Schedule t -> Schedule t
 makeDense s = fromMaybe (emptyRange 0) $ do
@@ -129,8 +138,7 @@ runTestB p = do
 
 runTestE :: (MonadReflexHost t m, MonadIORef m, NFData a) => Plan t (Event t a) -> m (IntMap (Maybe a))
 runTestE p = do
-  (e, s) <- runPlan p
-  h <- subscribeEvent e
+  (h, s) <- setupFiring p
   testSchedule s (readEvent' h)
 
 

--- a/test/Reflex/Test/CrossImpl.hs
+++ b/test/Reflex/Test/CrossImpl.hs
@@ -77,18 +77,20 @@ instance (MapMSignals a a' t t', MapMSignals b b' t t') => MapMSignals (a, b) (a
 testTimeline
   :: (forall m t. TestCaseConstraint t m => (Behavior t a, Event t b) -> m (Behavior t c, Event t d))
   -> (Map Int a, Map Int b)
-  -> (forall m t. (MonadReflexHost t m, MonadIO m, MonadRef m, Ref m ~ Ref IO, MonadSample t m) => m (Map Int c, Map Int d))
+  -> (forall m t. (MonadReflexHost t m, MonadIO m, MonadRef m, Ref m ~ Ref IO) => m (Map Int c, Map Int d))
 testTimeline builder (bMap, eMap) = do
   (re, reTrigger) <- newEventWithTriggerRef
   (rb, rbTrigger) <- newEventWithTriggerRef
-  b <- runHostFrame $ hold (error "testTimeline: No value for input behavior yet") rb
-  (b', e') <- runHostFrame $ builder (b, re)
-  e'Handle <- subscribeEvent e' --TODO: This should be unnecessary
+  (b, b', e'Handle) <- runHostFrame $ do
+    b <- hold (error "testTimeline: No value for input behavior yet") rb
+    (b', e') <- builder (b, re)
+    e'Handle <- subscribeEvent e'
+    pure (b, b', e'Handle)
   let times = relevantTestingTimes (bMap, eMap)
   liftIO performGC
   outputs <- forM times $ \t -> do
     forM_ (Map.lookup t bMap) $ \val -> mapM_ (\ rbt -> fireEvents [rbt :=> Identity val]) =<< readRef rbTrigger
-    bOutput <- sample b'
+    bOutput <- runHostFrame $ sample b'
     eOutput <- fmap join $ forM (Map.lookup t eMap) $ \val -> do
       mret <- readRef reTrigger
       let firing = case mret of

--- a/test/Reflex/Test/Micro.hs
+++ b/test/Reflex/Test/Micro.hs
@@ -391,7 +391,7 @@ testCases =
       let e = pushAlways (\a -> if a == "a" then now else return never) e1
       x <- accumDyn (<>) never e
       return . coincidence $ updated x
-  , xfail ["spider"] $ testE "now-4" $ do
+  , testE "now-4" $ do
       now
   , testE "now-5" $ do
       e1 <- events1
@@ -400,7 +400,7 @@ testCases =
       e1 <- events1
       n <- now
       pure $ coincidence $ pushAlways (const (pure n)) e1
-  , xfail ["spider"] $ testE "now-7" $ do
+  , testE "now-7" $ do
       e1 <- plan [(0,"a"),(1,"b"),(3,"c")]
       n <- now
       pure $ coincidence $ pushAlways (const (pure n)) e1

--- a/test/Test/Run.hs
+++ b/test/Test/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 module Test.Run where
 
 import Control.Monad
@@ -29,34 +30,38 @@ runApp :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
 runApp app b0 input = runSpiderHost $ do
   (appInHoldE, pulseHoldTriggerRef) <- newEventWithTriggerRef
   (appInE, pulseEventTriggerRef) <- newEventWithTriggerRef
-  (out, FireCommand fire) <- hostPerformEventT $ do
-    appInB <- hold b0 appInHoldE
-    app $ AppIn
-      { _appIn_event = appInE
-      , _appIn_behavior = appInB
-      }
-  hnd <- runHostFrame $ subscribeEvent (_appOut_event out)
-  mpulseB <- readRef pulseHoldTriggerRef
-  mpulseE <- readRef pulseEventTriggerRef
-  let readPhase = do
+  let readPhase out hnd = do
         b <- sample (_appOut_behavior out)
         frames <- sequence =<< readEvent hnd
         return (b, frames)
+  let step (out, hnd) acc = (\x -> Right @() (x : acc)) <$> readPhase out hnd
+  (_, outAndHandle, _, FireCommand fire) <-
+    hostPerformEventTAndRead
+    (do appInB <- hold b0 appInHoldE
+        app $ AppIn
+          { _appIn_event = appInE
+          , _appIn_behavior = appInB
+          })
+    (\o -> (,) o <$> subscribeEvent (_appOut_event o))
+    []
+    step
+  mpulseB <- readRef pulseHoldTriggerRef
+  mpulseE <- readRef pulseEventTriggerRef
+  let fireCollect triggers = either (const []) reverse <$> fire triggers [] (step outAndHandle)
   forM input $ \case
-    Nothing ->
-      fire [] $ readPhase
+    Nothing -> fireCollect []
     Just i -> case i of
       This b' -> case mpulseB of
         Nothing -> error "tried to fire in-behavior but ref was empty"
-        Just pulseB -> fire [ pulseB :=> Identity b' ] $ readPhase
+        Just pulseB -> fireCollect [ pulseB :=> Identity b' ]
       That e' -> case mpulseE of
         Nothing -> error "tried to fire in-event but ref was empty"
-        Just pulseE -> fire [ pulseE :=> Identity e' ] $ readPhase
+        Just pulseE -> fireCollect [ pulseE :=> Identity e' ]
       These b' e' -> case mpulseB of
         Nothing -> error "tried to fire in-behavior but ref was empty"
         Just pulseB -> case mpulseE of
           Nothing -> error "tried to fire in-event but ref was empty"
-          Just pulseE -> fire [ pulseB :=> Identity b', pulseE :=> Identity e' ] $ readPhase
+          Just pulseE -> fireCollect [ pulseB :=> Identity b', pulseE :=> Identity e' ]
 
 runApp' :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
         => (Event t eIn -> PerformEventT t m (Event t eOut))

--- a/test/Test/Run.hs
+++ b/test/Test/Run.hs
@@ -29,12 +29,13 @@ runApp :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
 runApp app b0 input = runSpiderHost $ do
   (appInHoldE, pulseHoldTriggerRef) <- newEventWithTriggerRef
   (appInE, pulseEventTriggerRef) <- newEventWithTriggerRef
-  appInB <- hold b0 appInHoldE
-  (out, FireCommand fire) <- hostPerformEventT $ app $ AppIn
-    { _appIn_event = appInE
-    , _appIn_behavior = appInB
-    }
-  hnd <- subscribeEvent (_appOut_event out)
+  (out, FireCommand fire) <- hostPerformEventT $ do
+    appInB <- hold b0 appInHoldE
+    app $ AppIn
+      { _appIn_event = appInE
+      , _appIn_behavior = appInB
+      }
+  hnd <- runHostFrame $ subscribeEvent (_appOut_event out)
   mpulseB <- readRef pulseHoldTriggerRef
   mpulseE <- readRef pulseEventTriggerRef
   let readPhase = do

--- a/test/rootCleanup.hs
+++ b/test/rootCleanup.hs
@@ -14,7 +14,7 @@ main = do
       e <- newEventWithTrigger $ \_ -> do
         modifyIORef' numSubscriptions succ
         return $ modifyIORef' numSubscriptions pred
-      _ <- hold () e
+      _ <- runHostFrame $ hold () e
       return ()
     replicateM_ 100 $ do
       performMajorGC

--- a/test/runHostFrame.hs
+++ b/test/runHostFrame.hs
@@ -1,10 +1,11 @@
--- | 'runHostFrame' contains some optimizations which broke Spider when Reflex
--- gained `now`.
+-- | A frame run by 'runHostFrame' is a full instant: a build-time 'now'
+-- occurrence must reach every hold in the built network, including through
+-- combinators (such as merges) whose occurrences are computed by propagation
+-- rather than read directly at subscribe time.
 import qualified Data.IntMap as IntMap
 import Reflex
 import Reflex.Host.Class
 import Test.Tasty
-import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit
 
 main :: IO ()
@@ -16,8 +17,7 @@ main = defaultMain $ testGroup "runHostFrame"
           hold "initial" ("fired" <$ buildTime)
         runHostFrame $ sample b
       value @?= "fired"
-  , expectFailBecause "runHostFrame never drains the delayed-merge queue, so the merge's occurrence is lost" $
-      testCase "hold on mergeInt of now" $ do
+  , testCase "hold on mergeInt of now" $ do
         value <- runSpiderHost $ do
           b <- runHostFrame $ do
             buildTime <- now


### PR DESCRIPTION
This MR improves how Reflex Spider handles the progression of time. Previously it would be very to accidentally advance time, and Reflex hosts did things which made `now` useless on the first frame of a program.

With this work the program lifecycle is handled much more rigidly, preventing mistakes from being made when writing Reflex Hosts.

I'm deprecating `PostBuild` and `getPostBuild` since we can simply use the denotive `now` primitive instead. The tests which no longer are marked failing attest to this.

The changes might break some (many?) programs, but should only require adding `MonadHold t m` to constraint lists so this is just a mechanical refactoring.

Verified compatible with `reflex-vty` and `reflex-dom`.

Breaking changes:

## Reflex.Host
I've changed the way Reflex hosts run frames, making it much more obvious when you're running a frame, and when you're reading event occurrences. 

I've deleted the `MonadHold` and `MonadSample` instances of `SpiderHost` since this was asking for trouble and partly a cause of the `now` t₀ breakage. (These instances were doing a `runFrame` on every hold/sample/etc. even though these are pure functions not meant to have side effects.)

## Reflex.PerformEvent.Base
New `hostPerformEventTAndRead` function and `hostPerformEventT` signature which allow early exit from running events. These change in accordance with the `MonadReflexHost` changes.

Before, a program which already knew it wanted to exit would still execute the remaining "PerformEvent cascade" fully. (hostPerformEventT can result in multple frames being executed, because effects can trigger more effects).

## PostBuild constraint changes

`PostBuild` now requires `MonadHold`. I've removed PostBuild internally, set `getPostBuild` to `now`.